### PR TITLE
Docs: content extraction, markdown-to-HTML, and new test files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ openclaw-on-agentcore/
     lightweight-agent.test.js     # Lightweight agent unit tests (node:test, 70 tests)
     agentcore-proxy.js            # OpenAI -> Bedrock ConverseStream adapter + Identity + multimodal images
     image-support.test.js         # Image support unit tests (node:test)
+    content-extraction.test.js    # Content block extraction tests (node:test)
     workspace-sync.js             # .openclaw/ directory S3 sync (restore/save/periodic)
     force-ipv4.js                 # DNS patch for Node.js 22 IPv6 issue
     skills/
@@ -132,8 +133,10 @@ openclaw-on-agentcore/
   lambda/
     token_metrics/index.py        # Bedrock log -> DynamoDB + CloudWatch metrics
     router/index.py               # Webhook router (Telegram + Slack, image uploads)
-    router/test_image_upload.py   # Image upload unit tests (pytest)
-    cron/index.py                 # Cron executor (warmup, invoke, deliver to channel)
+    router/test_image_upload.py        # Image upload unit tests (pytest)
+    router/test_content_extraction.py  # Content block extraction tests (pytest)
+    router/test_markdown_html.py       # Markdown-to-HTML conversion tests (pytest)
+    cron/index.py                      # Cron executor (warmup, invoke, deliver to channel)
   scripts/
     setup-telegram.sh             # Telegram webhook + admin allowlist (one-step)
     setup-slack.sh                # Slack Event Subscriptions + admin allowlist
@@ -251,12 +254,15 @@ cd bridge && node --test proxy-identity.test.js       # identity + workspace tes
 cd bridge && node --test image-support.test.js         # image upload + multimodal tests
 cd bridge && node --test lightweight-agent.test.js     # lightweight agent tools + buildToolArgs tests
 cd bridge && node --test subagent-routing.test.js      # subagent model routing + detection tests
+cd bridge && node --test content-extraction.test.js    # recursive content block extraction tests
 cd bridge/skills/s3-user-files && AWS_REGION=$CDK_DEFAULT_REGION node --test common.test.js  # S3 skill tests
 ```
 
 ### Router Lambda Tests
 ```bash
-cd lambda/router && python -m pytest test_image_upload.py -v   # image upload unit tests
+cd lambda/router && python -m pytest test_image_upload.py -v        # image upload unit tests
+cd lambda/router && python -m pytest test_content_extraction.py -v  # content block extraction tests
+cd lambda/router && python -m pytest test_markdown_html.py -v       # markdown-to-HTML conversion tests
 ```
 
 ### E2E Tests
@@ -444,6 +450,8 @@ Only the **first channel identity** needs to be allowlisted. When a user binds a
 - **Slack**: Handles `url_verification` challenge synchronously; ignores retries via `x-slack-retry-num` header
 - **Cold start latency**: First message to a new user triggers microVM creation; lightweight agent responds in ~10-15s while OpenClaw starts in background (~2-4 min)
 - **Typing indicator + progress message**: Telegram typing indicator sent every 4s while waiting; after 30s of waiting, a one-time progress message ("Working on your request...") is sent to both Telegram and Slack so users know the bot is still working during long subagent tasks
+- **Content block extraction**: `_extract_text_from_content_blocks()` recursively unwraps nested `[{"type":"text","text":"..."}]` JSON — subagent responses (deep-research-pro, task-decomposer) can wrap content multiple levels deep
+- **Markdown-to-HTML conversion**: `_markdown_to_telegram_html()` converts markdown to Telegram-compatible HTML before sending. Handles bold, italic, strikethrough, code blocks, inline code, headers, links, blockquotes, horizontal rules, and markdown tables (rendered as monospace `<pre>` blocks with aligned columns). Uses `parse_mode: "HTML"` (not `"Markdown"` v1 which is too strict for AI-generated content)
 - **Cross-channel binding**: "link accounts" generates 6-char code in DynamoDB with 10-min TTL
 - **Image uploads**: Telegram photos and Slack file attachments (JPEG, PNG, GIF, WebP, max 3.75 MB) are downloaded by the Router Lambda, uploaded to S3 under `{namespace}/_uploads/`, and passed to AgentCore as a structured message `{text, images[{s3Key, contentType}]}`
 - **Telegram captions**: `message.get("text", "") or message.get("caption", "")` — photos use `caption`, not `text`

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ openclaw-on-agentcore/
     lightweight-agent.test.js     # Lightweight agent unit tests (node:test, 70 tests)
     agentcore-proxy.js            # OpenAI -> Bedrock ConverseStream adapter + Identity + multimodal images
     image-support.test.js         # Image support unit tests (node:test)
+    content-extraction.test.js    # Content block extraction tests (node:test)
     subagent-routing.test.js      # Subagent model routing + detection tests (node:test)
     workspace-sync.js             # .openclaw/ directory S3 sync (restore/save/periodic)
     force-ipv4.js                 # DNS patch for Node.js 22 IPv6 issue
@@ -255,9 +256,11 @@ openclaw-on-agentcore/
       eventbridge-cron/           # Cron scheduling skill (EventBridge Scheduler)
   lambda/
     token_metrics/index.py        # Bedrock log -> DynamoDB + CloudWatch metrics
-    router/index.py               # Webhook router (Telegram + Slack, image uploads)
-    router/test_image_upload.py   # Image upload unit tests (pytest)
-    cron/index.py                 # Cron executor (warmup, invoke, deliver)
+    router/index.py                    # Webhook router (Telegram + Slack, image uploads)
+    router/test_image_upload.py        # Image upload unit tests (pytest)
+    router/test_content_extraction.py  # Content block extraction tests (pytest)
+    router/test_markdown_html.py       # Markdown-to-HTML conversion tests (pytest)
+    cron/index.py                      # Cron executor (warmup, invoke, deliver)
   scripts/
     setup-telegram.sh             # Telegram webhook + admin allowlist (one-step)
     setup-slack.sh                # Slack Event Subscriptions + admin allowlist
@@ -526,7 +529,7 @@ Each user's schedules are isolated — no cross-user access. Schedule metadata i
 4. Lambda calls `InvokeAgentRuntime` with per-user session ID
 5. Contract server triggers lazy init (first message) or bridges to OpenClaw directly
 6. Proxy converts to Bedrock ConverseStream API call (multimodal if images present)
-7. Response streams back → Lambda sends to channel API
+7. Response streams back → Lambda recursively unwraps nested content blocks (from subagent responses), converts markdown to Telegram HTML, sends to channel API
 
 ### Tools & Skills
 
@@ -611,8 +614,11 @@ cd bridge && node --test proxy-identity.test.js       # identity + workspace tes
 cd bridge && node --test image-support.test.js         # image upload + multimodal tests
 cd bridge && node --test lightweight-agent.test.js     # lightweight agent tools + buildToolArgs tests
 cd bridge && node --test subagent-routing.test.js      # subagent model routing + detection tests
+cd bridge && node --test content-extraction.test.js    # recursive content block extraction tests
 cd bridge/skills/s3-user-files && AWS_REGION=$CDK_DEFAULT_REGION node --test common.test.js  # S3 skill tests
-cd lambda/router && python -m pytest test_image_upload.py -v   # image upload unit tests
+cd lambda/router && python -m pytest test_image_upload.py -v        # image upload unit tests
+cd lambda/router && python -m pytest test_content_extraction.py -v  # content block extraction tests
+cd lambda/router && python -m pytest test_markdown_html.py -v       # markdown-to-HTML conversion tests
 
 # E2E tests (requires deployed stack + E2E_TELEGRAM_CHAT_ID/E2E_TELEGRAM_USER_ID env vars)
 pytest tests/e2e/bot_test.py -v -k smoke               # connectivity + webhook auth

--- a/docs/architecture-detailed.md
+++ b/docs/architecture-detailed.md
@@ -108,7 +108,8 @@ sequenceDiagram
     end
 
     AC-->>RL: Final response
-    RL->>C: Send message
+    Note over RL: Unwrap nested content blocks<br/>Convert markdown → Telegram HTML
+    RL->>C: Send message (HTML formatted)
     C->>U: Display response
 ```
 


### PR DESCRIPTION
## Summary

Documentation update for recent features:

- Document content extraction from nested subagent responses
- Document markdown-to-HTML conversion for Telegram
- Document new test files (content-extraction.test.js, test_content_extraction.py, test_markdown_html.py)

## Test plan

- [x] Documentation only - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)