### PR TITLE
fix: Use AccountPrincipal with ArnLike condition for IAM role self-as…

### DIFF
--- a/stacks/agentcore_stack.py
+++ b/stacks/agentcore_stack.py
@@ -156,8 +156,11 @@ class AgentCoreStack(Stack):
         self.execution_role.assume_role_policy.add_statements(
             iam.PolicyStatement(
                 actions=["sts:AssumeRole"],
-                principals=[iam.ArnPrincipal(execution_role_arn_str)],
+                principals=[iam.AccountPrincipal(account)],
                 conditions={
+                    "ArnLike": {
+                        "aws:PrincipalArn": execution_role_arn_str,
+                    },
                     "StringLike": {
                         "sts:RoleSessionName": "scoped-*"
                     }


### PR DESCRIPTION
 Title:
  fix: Use AccountPrincipal with ArnLike condition for IAM role self-assume

  Body:
  ## Summary

  Fix IAM role creation failure when the execution role's trust policy references itself using `ArnPrincipal`.

  ## Problem

  When deploying the stack, IAM validation fails with:
  Invalid principal in policy: "AWS":"arn:aws:iam::{account}:role/openclaw-agentcore-execution-role"

  This occurs because IAM validates that the principal ARN exists at policy creation time, but the role hasn't been created yet (chicken-and-egg problem).

  ## Solution

  Replace `ArnPrincipal` with `AccountPrincipal` combined with an `ArnLike` condition:

  ```python
  # Before (fails)
  self.execution_role.assume_role_policy.add_statements(
      iam.PolicyStatement(
          actions=["sts:AssumeRole"],
          principals=[iam.ArnPrincipal(execution_role_arn_str)],
      )
  )

  # After (works)
  self.execution_role.assume_role_policy.add_statements(
      iam.PolicyStatement(
          actions=["sts:AssumeRole"],
          principals=[iam.AccountPrincipal(account)],
          conditions={
              "ArnLike": {
                  "aws:PrincipalArn": execution_role_arn_str,
              }
          },
      )
  )

  This achieves the same security constraint (only the specific role ARN can assume itself) while avoiding the IAM validation issue during stack creation.

  Test Plan

  - cdk synth completes without IAM validation errors
  - cdk deploy OpenClawAgentCore succeeds
  - STS self-assume works correctly for per-user S3 credential scoping

  References

  - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
