### PR TITLE
fix: scoped credentials DynamoDB LeadingKeys for cron ownership records

### DIFF
--- a/.claude/skills/e2e-bot-testing.md
+++ b/.claude/skills/e2e-bot-testing.md
@@ -31,6 +31,8 @@ export CDK_DEFAULT_REGION=ap-southeast-2
 | `pytest tests/e2e/bot_test.py -v -k subagent` | Sub-agent skill verification |
 | `pytest tests/e2e/bot_test.py -v -k ScopedCredentials` | Scoped S3 credentials (file ops) |
 | `pytest tests/e2e/bot_test.py -v -k TestApiKeyManagement` | API key storage (native + Secrets Manager) |
+| `pytest tests/e2e/bot_test.py -v -k TestSkillManagement` | ClawHub skill install/uninstall lifecycle |
+| `pytest tests/e2e/bot_test.py -v -k TestCronSchedule` | Cron schedule lifecycle + DynamoDB CRON# record verification |
 | `pytest tests/e2e/bot_test.py -v -k conversation` | Multi-turn conversation tests |
 | `pytest tests/e2e/bot_test.py -v` | All E2E tests |
 | `pytest -m "not e2e"` | Skip E2E tests in fast CI |
@@ -47,6 +49,8 @@ export CDK_DEFAULT_REGION=ap-southeast-2
 | `python -m tests.e2e.bot_test --subagent --tail-logs` | Sub-agent skill test |
 | `python -m tests.e2e.bot_test --scoped-creds --tail-logs` | Scoped credentials test |
 | `python -m tests.e2e.bot_test --api-keys --tail-logs` | API key management test (native + SM) |
+| `python -m tests.e2e.bot_test --skill-manage --tail-logs` | Skill management test (list, install, uninstall) |
+| `python -m tests.e2e.bot_test --cron --tail-logs` | Cron schedule lifecycle test (create, verify DynamoDB, list, delete) |
 
 ## Startup Phases and Timing
 
@@ -157,6 +161,60 @@ python -m tests.e2e.bot_test --api-keys --tail-logs
 
 **Test resets session** to force warm-up mode, since API key tools are lightweight agent tools (not OpenClaw skills).
 
+### Skill management verification (TestSkillManagement)
+
+Tests the clawhub-manage skill lifecycle: list installed skills, install a new skill, verify it appears, uninstall it, and verify it's gone. Runs during warm-up mode (lightweight agent) since the clawhub-manage tool is available immediately.
+
+```bash
+# Run skill management tests only
+pytest tests/e2e/bot_test.py -v -k TestSkillManagement
+
+# Ad-hoc CLI testing
+python -m tests.e2e.bot_test --skill-manage --tail-logs
+```
+
+**What the tests verify:**
+1. List pre-installed skills (baseline check — 5 ClawHub skills expected)
+2. Install a test skill (`hackernews` — lightweight, no API key)
+3. Verify the installed skill appears in the list
+4. Uninstall the test skill
+5. Verify the skill is removed from the list
+
+**Test resets session** to force warm-up mode. After install/uninstall, the skill changes take effect on the next session start (after idle timeout).
+
+### Cron schedule verification (TestCronSchedule)
+
+Tests the eventbridge-cron skill lifecycle and **critically verifies DynamoDB CRON# records are created under the correct partition key**. This test catches scoped credential misconfigurations where DynamoDB LeadingKeys exclude the internal userId — the exact bug that caused cron schedules to silently stop executing in March 2026.
+
+```bash
+# Run cron tests only
+pytest tests/e2e/bot_test.py -v -k TestCronSchedule
+
+# Ad-hoc CLI testing
+python -m tests.e2e.bot_test --cron --tail-logs
+```
+
+**What the tests verify:**
+1. Create a far-future one-time schedule (`cron(0 0 1 1 ? 2099)`) — never fires
+2. **CRON# DynamoDB record exists under `USER#{internalUserId}`** — the critical regression check
+3. EventBridge schedule exists with correct expression and state
+4. Bot can list schedules and see the test schedule (reads DynamoDB via scoped creds)
+5. Bot can delete the schedule
+6. CRON# DynamoDB record is cleaned up after deletion
+7. EventBridge schedule is cleaned up after deletion
+
+**Why this test matters:**
+The cron executor Lambda verifies schedule ownership by looking up `CRON#{scheduleId}` under `USER#{internalUserId}` (e.g., `USER#user_abc123`). If the scoped credentials only allow `USER#{actorId}` (e.g., `USER#telegram:12345`), the cron skill can create EventBridge schedules but silently fails to write the DynamoDB ownership record. Schedules appear to work but the Lambda rejects every execution with "Schedule not owned by user — skipping execution."
+
+**Test resets session** to start clean. Cleanup fixture removes stale test schedules from prior runs (both EventBridge and DynamoDB).
+
+| Troubleshooting | Cause | Fix |
+|----------------|-------|-----|
+| `test_cron_record_exists` fails | Scoped credentials DynamoDB LeadingKeys missing `USER#{internalUserId}` | Add `internalUserId` to `buildSessionPolicy()` in `scoped-credentials.js` |
+| `test_create_schedule` timeout | eventbridge-cron skill not in lightweight agent TOOLS array | Check `lightweight-agent.js` has `create_schedule` tool |
+| `test_list_schedules` shows empty | Scoped creds can't read `USER#{internalUserId}` CRON# records | Same fix as `test_cron_record_exists` |
+| `test_eventbridge_schedule_exists` fails | Scheduler IAM permissions missing | Check `scoped-credentials.js` includes `scheduler:CreateSchedule` |
+
 ## How It Works
 
 ### Architecture
@@ -204,8 +262,10 @@ The `AgentCore response body` line contains JSON: `{"response": "full text..."}`
 | `TestWarmupShim` | Warm-up footer present on cold start | ✓ | ✓ |
 | `TestFullStartup` | Full OpenClaw ready + phase timing | ✓ | ✓ |
 | `TestSubagent` | Sub-agent skill verification | | |
-| `TestApiKeyManagement` | API key storage (native + SM) | ✓ | |
 | `TestScopedCredentials` | S3 file ops via scoped STS creds | | |
+| `TestApiKeyManagement` | API key storage (native + SM) | ✓ | |
+| `TestSkillManagement` | ClawHub skill install/uninstall | ✓ | |
+| `TestCronSchedule` | Cron lifecycle + DynamoDB CRON# record | ✓ | |
 | `TestConversation` | Multi-turn scenarios | | |
 
 ### Conversation Scenarios
@@ -287,7 +347,14 @@ pytest tests/e2e/bot_test.py -v -k full_startup
 #    (Requires full OpenClaw; waits for startup if needed)
 pytest tests/e2e/bot_test.py -v -k subagent
 
-# 7. Conversations — multi-turn and rapid-fire
+# 7. Cron schedule — create, verify CRON# DynamoDB record, list, delete
+#    (Critical for scoped credentials validation)
+pytest tests/e2e/bot_test.py -v -k TestCronSchedule
+
+# 8. Skill management — install/uninstall ClawHub skills
+pytest tests/e2e/bot_test.py -v -k TestSkillManagement
+
+# 9. Conversations — multi-turn and rapid-fire
 pytest tests/e2e/bot_test.py -v -k conversation
 
 # Or run everything:

--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -540,7 +540,7 @@ async function init(userId, actorId, channel) {
     if (process.env.EXECUTION_ROLE_ARN) {
       try {
         console.log(`[contract] Creating scoped S3 credentials for namespace=${namespace}...`);
-        const creds = await scopedCreds.createScopedCredentials(namespace);
+        const creds = await scopedCreds.createScopedCredentials(namespace, { internalUserId: userId });
         scopedCreds.writeCredentialFiles(creds, SCOPED_CREDS_DIR);
         workspaceSync.configureCredentials(creds);
         scopedCredsAvailable = true;
@@ -551,7 +551,7 @@ async function init(userId, actorId, channel) {
         credentialRefreshTimer = setInterval(async () => {
           try {
             console.log("[contract] Refreshing scoped S3 credentials...");
-            const refreshed = await scopedCreds.createScopedCredentials(namespace);
+            const refreshed = await scopedCreds.createScopedCredentials(namespace, { internalUserId: userId });
             scopedCreds.writeCredentialFiles(refreshed, SCOPED_CREDS_DIR);
             workspaceSync.configureCredentials(refreshed);
             console.log("[contract] Scoped S3 credentials refreshed");

--- a/bridge/scoped-credentials.js
+++ b/bridge/scoped-credentials.js
@@ -58,7 +58,7 @@ const FORWARDED_ENV_KEYS = [
  * @param {string} [opts.scheduleGroupArn] - EventBridge schedule group ARN (scopes scheduler access)
  * @returns {string} JSON policy document
  */
-function buildSessionPolicy({ bucket, namespace, actorId, cmkArn, eventbridgeRoleArn, identityTableArn, scheduleGroupArn, region, account }) {
+function buildSessionPolicy({ bucket, namespace, actorId, internalUserId, cmkArn, eventbridgeRoleArn, identityTableArn, scheduleGroupArn, region, account }) {
   if (!namespace || !VALID_NAMESPACE.test(namespace)) {
     throw new Error(
       `Invalid namespace "${namespace}" — must match ${VALID_NAMESPACE}`,
@@ -150,6 +150,11 @@ function buildSessionPolicy({ bucket, namespace, actorId, cmkArn, eventbridgeRol
               "dynamodb:LeadingKeys": [
                 `USER#${actorId}`,
                 `CHANNEL#${actorId}`,
+                // Internal userId PK — CRON# records and SESSION records
+                // are stored under USER#{internalUserId} (e.g. USER#user_abc123)
+                ...(internalUserId && internalUserId !== actorId
+                  ? [`USER#${internalUserId}`]
+                  : []),
               ]
             }
           },
@@ -196,6 +201,7 @@ function buildSessionPolicy({ bucket, namespace, actorId, cmkArn, eventbridgeRol
  * @param {string} namespace - User namespace (e.g. "telegram_12345")
  * @param {object} [opts] - Options
  * @param {object} [opts.stsClient] - Pre-configured STS client (for testing)
+ * @param {string} [opts.internalUserId] - Internal user ID (e.g. "user_abc123") for DynamoDB CRON#/SESSION access
  * @returns {Promise<{accessKeyId: string, secretAccessKey: string, sessionToken: string, expiration: Date}>}
  */
 async function createScopedCredentials(namespace, opts = {}) {
@@ -232,7 +238,8 @@ async function createScopedCredentials(namespace, opts = {}) {
   const actorId = namespace.replace(/_/, ":");
 
   const sessionPolicy = buildSessionPolicy({
-    bucket, namespace, actorId, cmkArn, eventbridgeRoleArn,
+    bucket, namespace, actorId, internalUserId: opts.internalUserId,
+    cmkArn, eventbridgeRoleArn,
     identityTableArn, scheduleGroupArn, region, account,
   });
 

--- a/bridge/scoped-credentials.test.js
+++ b/bridge/scoped-credentials.test.js
@@ -218,6 +218,39 @@ describe("buildSessionPolicy", () => {
     assert.equal(dynamoStmt.Resource, "*", "should fall back to wildcard");
   });
 
+  it("includes internalUserId in DynamoDB LeadingKeys when provided", () => {
+    const policy = buildSessionPolicy({
+      bucket: "my-bucket",
+      namespace: "telegram_12345",
+      actorId: "telegram:12345",
+      internalUserId: "user_abc123",
+      identityTableArn: "arn:aws:dynamodb:us-west-2:123456789012:table/openclaw-identity",
+    });
+
+    const parsed = JSON.parse(policy);
+    const dynamoStmt = parsed.Statement.find((s) => s.Sid === "DynamoDBIdentity");
+    assert.ok(dynamoStmt, "should have DynamoDB statement");
+    const leadingKeys = dynamoStmt.Condition["ForAllValues:StringLike"]["dynamodb:LeadingKeys"];
+    assert.ok(leadingKeys.includes("USER#telegram:12345"), "should include actorId-based PK");
+    assert.ok(leadingKeys.includes("CHANNEL#telegram:12345"), "should include channel PK");
+    assert.ok(leadingKeys.includes("USER#user_abc123"), "should include internal userId PK for CRON records");
+    assert.equal(leadingKeys.length, 3, "should have exactly 3 leading key patterns");
+  });
+
+  it("omits duplicate internalUserId when same as actorId", () => {
+    const policy = buildSessionPolicy({
+      bucket: "my-bucket",
+      namespace: "telegram_12345",
+      actorId: "telegram:12345",
+      internalUserId: "telegram:12345",
+    });
+
+    const parsed = JSON.parse(policy);
+    const dynamoStmt = parsed.Statement.find((s) => s.Sid === "DynamoDBIdentity");
+    const leadingKeys = dynamoStmt.Condition["ForAllValues:StringLike"]["dynamodb:LeadingKeys"];
+    assert.equal(leadingKeys.length, 2, "should not duplicate when internalUserId matches actorId");
+  });
+
   it("scopes EventBridge CRUD to schedule group schedules when provided", () => {
     const policy = buildSessionPolicy({
       bucket: "my-bucket",

--- a/cdk.json
+++ b/cdk.json
@@ -10,7 +10,7 @@
     "daily_cost_budget_usd": 5,
     "anomaly_band_width": 2,
     "token_ttl_days": 90,
-    "image_version": 47,
+    "image_version": "48",
     "user_files_ttl_days": 365,
     "session_idle_timeout": 1800,
     "session_max_lifetime": 28800,

--- a/tests/e2e/bot_test.py
+++ b/tests/e2e/bot_test.py
@@ -9,6 +9,7 @@ CLI usage:
     python -m tests.e2e.bot_test --subagent --tail-logs
     python -m tests.e2e.bot_test --skill-manage --tail-logs
     python -m tests.e2e.bot_test --api-keys --tail-logs
+    python -m tests.e2e.bot_test --cron --tail-logs
 
 Pytest usage:
     pytest tests/e2e/bot_test.py -v -k smoke
@@ -891,6 +892,242 @@ class TestSkillManagement:
         print(f"  List response ({tail.response_len} chars): {tail.response_text[:300]}")
 
 
+class TestCronSchedule:
+    """Verify eventbridge-cron skill: create, list, and delete schedules.
+
+    Tests the full cron schedule lifecycle through the bot and critically
+    verifies the CRON# DynamoDB record is created — this catches scoped
+    credential issues where DynamoDB LeadingKeys exclude the internal userId.
+
+    Flow:
+      1. Create a far-future one-time schedule via the bot
+      2. Verify the CRON# record exists in DynamoDB (direct check)
+      3. List schedules via the bot and verify the test schedule appears
+      4. Delete the schedule via the bot
+      5. Verify the CRON# record is gone from DynamoDB
+      6. Verify the EventBridge schedule is gone
+
+    Uses the eventbridge-cron skill which works in both warm-up mode
+    (lightweight agent) and full OpenClaw mode.
+
+    Run with: pytest tests/e2e/bot_test.py -v -k TestCronSchedule
+    """
+
+    SCHEDULE_NAME = "e2e-cron-test"
+    # Far-future one-time schedule (Jan 1 2099) — never fires
+    SCHEDULE_EXPR = "cron(0 0 1 1 ? 2099)"
+    SCHEDULE_TZ = "UTC"
+    SCHEDULE_MSG = "E2E cron test - should never fire"
+    SCHEDULE_GROUP = "openclaw-cron"
+
+    # Populated by test_create_schedule for use by later tests
+    _schedule_id = None
+
+    @pytest.fixture(autouse=True, scope="class")
+    def fresh_session(self, e2e_config):
+        """Reset session to start clean, then clean up stale test schedules."""
+        # Clean up any leftover test schedules from prior runs
+        self._cleanup_stale_schedules(e2e_config)
+        reset_session(e2e_config)
+        time.sleep(2)
+
+    @classmethod
+    def _cleanup_stale_schedules(cls, cfg):
+        """Delete any leftover E2E test schedules from prior runs."""
+        namespace = f"telegram_{cfg.telegram_user_id}"
+        scheduler = boto3.client("scheduler", region_name=cfg.region)
+        try:
+            resp = scheduler.list_schedules(GroupName=cls.SCHEDULE_GROUP)
+            for sched in resp.get("Schedules", []):
+                name = sched["Name"]
+                if name.startswith(f"openclaw-{namespace}-") and cls.SCHEDULE_NAME in sched.get("Description", ""):
+                    try:
+                        scheduler.delete_schedule(
+                            Name=name, GroupName=cls.SCHEDULE_GROUP
+                        )
+                        print(f"\n  [cleanup] Deleted stale test schedule: {name}")
+                    except ClientError:
+                        pass
+        except ClientError:
+            pass
+
+        # Also clean up CRON# records that reference e2e-cron-test
+        user_id = get_user_id(cfg)
+        if user_id:
+            dynamodb = boto3.resource("dynamodb", region_name=cfg.region)
+            table = dynamodb.Table(cfg.identity_table)
+            try:
+                resp = table.query(
+                    KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+                    ExpressionAttributeValues={
+                        ":pk": f"USER#{user_id}",
+                        ":sk": "CRON#",
+                    },
+                )
+                for item in resp.get("Items", []):
+                    if item.get("scheduleName", "") == cls.SCHEDULE_NAME:
+                        table.delete_item(
+                            Key={"PK": item["PK"], "SK": item["SK"]}
+                        )
+                        print(f"\n  [cleanup] Deleted stale CRON# record: {item['SK']}")
+            except ClientError:
+                pass
+
+    def test_create_schedule(self, e2e_config):
+        """Create a one-time far-future schedule via the bot."""
+        since_ms = int(time.time() * 1000)
+        result = post_webhook(
+            e2e_config,
+            f'Create a cron schedule using the eventbridge-cron skill. '
+            f'Schedule name: "{self.SCHEDULE_NAME}". '
+            f'Expression: {self.SCHEDULE_EXPR}. '
+            f'Timezone: {self.SCHEDULE_TZ}. '
+            f'Message: "{self.SCHEDULE_MSG}". '
+            f'Do not ask any follow-up questions, just create it.',
+        )
+        assert result.status_code == 200
+
+        tail = tail_logs(e2e_config, since_ms=since_ms, timeout_s=300)
+        assert tail.full_lifecycle, (
+            f"Create schedule incomplete (timed_out={tail.timed_out}, "
+            f"elapsed={tail.elapsed_s:.1f}s)"
+        )
+        resp_lower = tail.response_text.lower()
+        assert any(w in resp_lower for w in ["created", "scheduled", "success"]), (
+            f"Expected schedule creation confirmation.\n"
+            f"Response: {tail.response_text[:300]}"
+        )
+        print(f"  Create schedule response: {tail.response_text[:200]}")
+
+    def test_cron_record_exists(self, e2e_config):
+        """Verify the CRON# record was created in DynamoDB.
+
+        This is the critical check: scoped credentials must allow writing
+        to USER#{internalUserId} (e.g., USER#user_abc123), not just
+        USER#{actorId} (e.g., USER#telegram:12345). Without this, the
+        cron executor Lambda will reject scheduled executions.
+        """
+        user_id = get_user_id(e2e_config)
+        assert user_id, "E2E user not found in DynamoDB"
+
+        dynamodb = boto3.resource("dynamodb", region_name=e2e_config.region)
+        table = dynamodb.Table(e2e_config.identity_table)
+        resp = table.query(
+            KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+            ExpressionAttributeValues={
+                ":pk": f"USER#{user_id}",
+                ":sk": "CRON#",
+            },
+        )
+        items = resp.get("Items", [])
+        matching = [
+            item for item in items
+            if item.get("scheduleName") == self.SCHEDULE_NAME
+        ]
+        assert len(matching) == 1, (
+            f"Expected exactly 1 CRON# record for '{self.SCHEDULE_NAME}', "
+            f"found {len(matching)}. All CRON# records: "
+            f"{[i.get('scheduleName') for i in items]}"
+        )
+        # Save schedule ID for later tests
+        TestCronSchedule._schedule_id = matching[0]["SK"].replace("CRON#", "")
+        print(f"  CRON# record found: scheduleId={TestCronSchedule._schedule_id}")
+
+    def test_eventbridge_schedule_exists(self, e2e_config):
+        """Verify the EventBridge schedule was created."""
+        assert TestCronSchedule._schedule_id, "No schedule ID from previous test"
+        namespace = f"telegram_{e2e_config.telegram_user_id}"
+        eb_name = f"openclaw-{namespace}-{TestCronSchedule._schedule_id}"
+
+        scheduler = boto3.client("scheduler", region_name=e2e_config.region)
+        try:
+            resp = scheduler.get_schedule(
+                Name=eb_name, GroupName=self.SCHEDULE_GROUP
+            )
+            assert resp["State"] == "ENABLED", f"Schedule state: {resp['State']}"
+            assert resp["ScheduleExpression"] == self.SCHEDULE_EXPR
+            print(f"  EventBridge schedule verified: {eb_name}")
+        except ClientError as e:
+            pytest.fail(
+                f"EventBridge schedule not found: {eb_name}. Error: {e}"
+            )
+
+    def test_list_schedules(self, e2e_config):
+        """List schedules via the bot and verify the test schedule appears."""
+        since_ms = int(time.time() * 1000)
+        result = post_webhook(
+            e2e_config,
+            "List all my cron schedules using the eventbridge-cron skill.",
+        )
+        assert result.status_code == 200
+
+        tail = tail_logs(e2e_config, since_ms=since_ms, timeout_s=300)
+        assert tail.full_lifecycle, (
+            f"List schedules incomplete (timed_out={tail.timed_out})"
+        )
+        resp_lower = tail.response_text.lower()
+        assert self.SCHEDULE_NAME in resp_lower, (
+            f"Expected '{self.SCHEDULE_NAME}' in schedule list.\n"
+            f"Response: {tail.response_text[:500]}"
+        )
+        print(f"  List schedules response: {tail.response_text[:300]}")
+
+    def test_delete_schedule(self, e2e_config):
+        """Delete the test schedule via the bot."""
+        assert TestCronSchedule._schedule_id, "No schedule ID from previous test"
+        since_ms = int(time.time() * 1000)
+        result = post_webhook(
+            e2e_config,
+            f'Delete the cron schedule with ID "{TestCronSchedule._schedule_id}" '
+            f'using the eventbridge-cron skill.',
+        )
+        assert result.status_code == 200
+
+        tail = tail_logs(e2e_config, since_ms=since_ms, timeout_s=300)
+        assert tail.full_lifecycle, (
+            f"Delete schedule incomplete (timed_out={tail.timed_out})"
+        )
+        resp_lower = tail.response_text.lower()
+        assert any(w in resp_lower for w in ["deleted", "removed", "success"]), (
+            f"Expected deletion confirmation.\n"
+            f"Response: {tail.response_text[:300]}"
+        )
+        print(f"  Delete schedule response: {tail.response_text[:200]}")
+
+    def test_cron_record_deleted(self, e2e_config):
+        """Verify the CRON# record was removed from DynamoDB after deletion."""
+        assert TestCronSchedule._schedule_id, "No schedule ID from previous test"
+        user_id = get_user_id(e2e_config)
+        assert user_id, "E2E user not found"
+
+        dynamodb = boto3.resource("dynamodb", region_name=e2e_config.region)
+        table = dynamodb.Table(e2e_config.identity_table)
+        resp = table.get_item(
+            Key={
+                "PK": f"USER#{user_id}",
+                "SK": f"CRON#{TestCronSchedule._schedule_id}",
+            }
+        )
+        assert "Item" not in resp, (
+            f"CRON# record still exists after deletion: {resp.get('Item')}"
+        )
+        print(f"  CRON# record confirmed deleted")
+
+    def test_eventbridge_schedule_deleted(self, e2e_config):
+        """Verify the EventBridge schedule was removed."""
+        assert TestCronSchedule._schedule_id, "No schedule ID from previous test"
+        namespace = f"telegram_{e2e_config.telegram_user_id}"
+        eb_name = f"openclaw-{namespace}-{TestCronSchedule._schedule_id}"
+
+        scheduler = boto3.client("scheduler", region_name=e2e_config.region)
+        try:
+            scheduler.get_schedule(Name=eb_name, GroupName=self.SCHEDULE_GROUP)
+            pytest.fail(f"EventBridge schedule still exists: {eb_name}")
+        except ClientError as e:
+            assert e.response["Error"]["Code"] == "ResourceNotFoundException"
+            print(f"  EventBridge schedule confirmed deleted: {eb_name}")
+
+
 class TestConversation:
     """Multi-message conversation tests."""
 
@@ -1160,6 +1397,94 @@ def _cli_api_keys(cfg, tail):
     return ok
 
 
+def _cli_cron(cfg, tail):
+    """Test cron schedule lifecycle: create, verify DynamoDB, list, delete."""
+    schedule_name = "e2e-cron-test"
+    schedule_expr = "cron(0 0 1 1 ? 2099)"
+    schedule_tz = "UTC"
+    schedule_msg = "E2E cron test - should never fire"
+
+    print("Cron schedule lifecycle test")
+
+    # Step 1: Create schedule
+    print(f"\n1. Creating schedule ({schedule_name})...")
+    ok = _cli_send(
+        cfg,
+        f'Create a cron schedule using the eventbridge-cron skill. '
+        f'Schedule name: "{schedule_name}". '
+        f'Expression: {schedule_expr}. '
+        f'Timezone: {schedule_tz}. '
+        f'Message: "{schedule_msg}". '
+        f'Do not ask any follow-up questions, just create it.',
+        tail,
+    )
+    if not ok:
+        return False
+    time.sleep(5)
+
+    # Step 2: Verify CRON# record in DynamoDB
+    print("\n2. Verifying CRON# record in DynamoDB...")
+    user_id = get_user_id(cfg)
+    if not user_id:
+        print("  FAIL: E2E user not found in DynamoDB")
+        return False
+
+    dynamodb = boto3.resource("dynamodb", region_name=cfg.region)
+    table = dynamodb.Table(cfg.identity_table)
+    resp = table.query(
+        KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+        ExpressionAttributeValues={
+            ":pk": f"USER#{user_id}",
+            ":sk": "CRON#",
+        },
+    )
+    matching = [
+        item for item in resp.get("Items", [])
+        if item.get("scheduleName") == schedule_name
+    ]
+    if not matching:
+        print(f"  FAIL: No CRON# record found for '{schedule_name}'")
+        print(f"  All CRON# records: {[i.get('scheduleName') for i in resp.get('Items', [])]}")
+        return False
+    schedule_id = matching[0]["SK"].replace("CRON#", "")
+    print(f"  OK: CRON# record found (scheduleId={schedule_id})")
+
+    # Step 3: List schedules
+    print("\n3. Listing schedules...")
+    ok = _cli_send(
+        cfg,
+        "List all my cron schedules using the eventbridge-cron skill.",
+        tail,
+    )
+    if not ok:
+        return False
+    time.sleep(5)
+
+    # Step 4: Delete schedule
+    print(f"\n4. Deleting schedule ({schedule_id})...")
+    ok = _cli_send(
+        cfg,
+        f'Delete the cron schedule with ID "{schedule_id}" '
+        f'using the eventbridge-cron skill.',
+        tail,
+    )
+    if not ok:
+        return False
+    time.sleep(3)
+
+    # Step 5: Verify CRON# record deleted
+    print("\n5. Verifying CRON# record deleted from DynamoDB...")
+    resp = table.get_item(
+        Key={"PK": f"USER#{user_id}", "SK": f"CRON#{schedule_id}"}
+    )
+    if "Item" in resp:
+        print(f"  FAIL: CRON# record still exists: {resp['Item']}")
+        return False
+    print("  OK: CRON# record deleted")
+
+    return True
+
+
 def _cli_conversation(cfg, scenario_name, tail):
     if scenario_name not in SCENARIOS:
         print(f"Unknown scenario: {scenario_name}")
@@ -1192,6 +1517,7 @@ def main():
     parser.add_argument("--scoped-creds", action="store_true", help="Test S3 file ops via scoped credentials (requires full startup)")
     parser.add_argument("--skill-manage", action="store_true", help="Test skill management (list, install, uninstall)")
     parser.add_argument("--api-keys", action="store_true", help="Test API key management (native + Secrets Manager)")
+    parser.add_argument("--cron", action="store_true", help="Test cron schedule lifecycle (create, verify CRON# record, list, delete)")
     parser.add_argument("--reset", action="store_true", help="Reset session before sending")
     parser.add_argument("--reset-user", action="store_true", help="Full user reset (delete all records)")
     parser.add_argument("--tail-logs", action="store_true", help="Tail CloudWatch logs to verify lifecycle")
@@ -1238,6 +1564,10 @@ def main():
         ok = _cli_api_keys(cfg, args.tail_logs)
         sys.exit(0 if ok else 1)
 
+    if args.cron:
+        ok = _cli_cron(cfg, args.tail_logs)
+        sys.exit(0 if ok else 1)
+
     if args.conversation:
         ok = _cli_conversation(cfg, args.conversation, args.tail_logs)
         sys.exit(0 if ok else 1)
@@ -1248,7 +1578,7 @@ def main():
 
     if not any([args.health, args.send, args.conversation, args.subagent,
                 args.scoped_creds, args.skill_manage, args.api_keys,
-                args.reset, args.reset_user]):
+                args.cron, args.reset, args.reset_user]):
         parser.print_help()
         sys.exit(1)
 


### PR DESCRIPTION
## Summary

- **Fix**: Include `USER#{internalUserId}` in STS session policy DynamoDB LeadingKeys so CRON# ownership records (stored under the internal userId, not the channel actorId) are accessible by scoped credentials
- **Root cause**: Cron schedules silently stopped executing because the cron executor Lambda's ownership check (`USER#{internalUserId}` + `CRON#{scheduleId}`) found no record — the scoped credential policy only allowed `USER#{actorId}` and `CHANNEL#{actorId}` prefixes
- **E2E regression test**: New `TestCronSchedule` class (7 tests) verifies the full cron lifecycle including a direct DynamoDB check for the CRON# record under the correct partition key

## Changes

- `bridge/scoped-credentials.js` — Add `internalUserId` param to `buildSessionPolicy()`, include in DynamoDB LeadingKeys with dedup
- `bridge/agentcore-contract.js` — Pass `internalUserId` through to `createScopedCredentials()`
- `bridge/scoped-credentials.test.js` — 2 new unit tests (44 total passing)
- `tests/e2e/bot_test.py` — `TestCronSchedule` class (7 tests) + `--cron` CLI handler
- `.claude/skills/e2e-bot-testing.md` — Document cron + skill management test classes
- `cdk.json` — Bump image_version 47→48

## Test plan

- [x] Unit tests: 44/44 passing (`node --test scoped-credentials.test.js`)
- [x] E2E full suite: 32/36 passing (4 pre-existing failures in ApiKey native + SkillManagement verify — unrelated)
- [x] All 7 CronSchedule tests passing — including critical `test_cron_record_exists` regression check
- [x] Deployed to ap-southeast-2 with v48 image, old session terminated, new session verified
- [x] Verify existing cron schedules fire on next execution window

🤖 Generated with [Claude Code](https://claude.com/claude-code)