### PR TITLE
Fix OpenClaw WebSocket auth "origin not allowed" error

### DIFF
--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -349,6 +349,7 @@ function writeOpenClawConfig() {
         enabled: false,
         allowInsecureAuth: true,
         dangerouslyDisableDeviceAuth: true,
+        dangerouslyAllowHostHeaderOriginFallback: true,
         allowedOrigins: ["*"],
       },
     },


### PR DESCRIPTION
## Summary
- Add `dangerouslyAllowHostHeaderOriginFallback: true` to OpenClaw gateway controlUi config
- Fixes "Auth failed: origin not allowed" error after OpenClaw 2026.2.23 breaking change

## Problem
After OpenClaw 2026.2.23 update, WebSocket connections to the gateway fail with:
Auth failed: origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)

## Solution
Added `dangerouslyAllowHostHeaderOriginFallback: true` to the controlUi configuration as recommended in the OpenClaw changelog.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
