### PR TITLE
fix(agentcore): avoid self-principal create-time trust failure

### DIFF
--- a/stacks/agentcore_stack.py
+++ b/stacks/agentcore_stack.py
@@ -185,10 +185,11 @@ class AgentCoreStack(Stack):
         self.execution_role.assume_role_policy.add_statements(
             iam.PolicyStatement(
                 actions=["sts:AssumeRole"],
-                principals=[iam.ArnPrincipal(execution_role_arn_str)],
+                principals=[iam.AnyPrincipal()],
                 conditions={
                     "StringLike": {
-                        "sts:RoleSessionName": "scoped-*"
+                        "aws:PrincipalArn": execution_role_arn_str,
+                        "sts:RoleSessionName": "scoped-*",
                     }
                 },
             )


### PR DESCRIPTION
*Issue #, if available:*
#39 

*Description of changes:*
Replace self ARN principal with AnyPrincipal guarded by aws:PrincipalArn and scoped role-session-name conditions so CloudFormation can create the role without invalid-principal errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
