### PR TITLE
fix(contract): prevent /ping from resetting AgentCore idle timer

### DIFF
--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -99,6 +99,9 @@ const OPENCLAW_RESTART_DELAY_MS = 5000;
 
 // Active task tracking — HealthyBusy prevents AgentCore from terminating during long tasks
 let activeTaskCount = 0;
+// Last activity timestamp (epoch seconds) — reported in /ping so AgentCore can track idle time.
+// Initialized to startup time; updated on each chat/cron/warmup invocation.
+let lastActivityTime = Math.floor(Date.now() / 1000);
 
 // Message queue for serializing concurrent requests (OpenClaw WebSocket path)
 let messageQueue = [];
@@ -1371,7 +1374,7 @@ const server = http.createServer(async (req, res) => {
     const status = activeTaskCount > 0 ? "HealthyBusy" : "Healthy";
     const responseBody = {
       status,
-      time_of_last_update: Math.floor(Date.now() / 1000),
+      time_of_last_update: lastActivityTime,
       active_tasks: activeTaskCount,
     };
 
@@ -1438,6 +1441,7 @@ const server = http.createServer(async (req, res) => {
 
         // Warmup action — trigger lazy init without blocking for a chat response
         if (action === "warmup") {
+          lastActivityTime = Math.floor(Date.now() / 1000);
           const { userId, actorId, channel } = payload;
           if (openclawReady && proxyReady) {
             res.writeHead(200, { "Content-Type": "application/json" });
@@ -1502,6 +1506,7 @@ const server = http.createServer(async (req, res) => {
           }
 
           // Track active task to prevent idle termination during cron processing
+          lastActivityTime = Math.floor(Date.now() / 1000);
           activeTaskCount++;
           let responseText;
           try {
@@ -1604,6 +1609,7 @@ const server = http.createServer(async (req, res) => {
           const bridgeText = buildBridgeText(message);
 
           // Track active task to prevent idle termination during chat processing
+          lastActivityTime = Math.floor(Date.now() / 1000);
           activeTaskCount++;
           let responseText;
           try {


### PR DESCRIPTION
## Problem

Sessions never terminate despite `idle_runtime_session_timeout: 1800s` (30 min). Containers survive 4+ hours with `status=Healthy` and `activeTasks=0`, accumulating 7000+ pings.

**Production logs showing the issue:**
```
/ping #6992 uptime=14787s status=Healthy activeTasks=0   <- 4.1 hours, should have terminated at 1800s
/ping #3932 uptime=8605s  status=Healthy activeTasks=0   <- 2.4 hours
```

## Root Cause

The `/ping` response includes `time_of_last_update`, which AgentCore uses to track when the session was last active. This field was set to `Date.now()` on **every ping** (~2s interval), continuously resetting the idle timer — making idle termination impossible regardless of the configured timeout.

Introduced in commit 13debee ("add HealthyBusy ping status") alongside the `activeTaskCount` feature.

## Fix

- Add `lastActivityTime` variable, initialized at startup
- Update it only on actual invocations: `chat`, `cron`, `warmup`
- `/ping` now reports the real last activity time instead of current time
- After 30 min with no invocations, `time_of_last_update` stays stale and AgentCore correctly terminates the idle session

## Test Plan

- [x] Deploy to us-west-2, stop existing sessions, send a test message
- [ ] Verify session terminates ~30 min after last message (check CloudWatch for SIGTERM log)
- [ ] Verify `HealthyBusy` still works during active chat/cron tasks (session should NOT terminate mid-task)
- [ ] Verify new session starts correctly after idle termination (workspace restored from S3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)