### PR TITLE
fix: exec tool, Telegram UX, proxy reliability, and maxTokens root cause fix

### DIFF
--- a/.bedrock_agentcore/openclaw_agent/Dockerfile
+++ b/.bedrock_agentcore/openclaw_agent/Dockerfile
@@ -12,7 +12,10 @@ RUN apt-get update && \
 RUN pip3 install --no-cache-dir --break-system-packages awscli
 
 # Install OpenClaw and ClawHub CLI globally
-RUN npm install -g openclaw@latest clawhub@latest
+# Pinned to tested versions — update intentionally to avoid unexpected breaking changes.
+# To upgrade: test the new version locally first, then bump both pins here.
+#   openclaw release notes: https://github.com/openclaw/openclaw/releases
+RUN npm install -g openclaw@2026.3.8 clawhub@0.8.0
 
 # Install ClawHub community skills (5 high-value marketplace skills)
 # Removed duckduckgo-search (redundant — lightweight agent has built-in web_search),
@@ -32,8 +35,11 @@ RUN mkdir -p /app
 WORKDIR /app
 
 # Install AWS SDK and WebSocket library (production only)
+# Skip browser binary download — we only need playwright-core for CDP client (connectOverCDP)
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 RUN cd /app && npm init -y > /dev/null 2>&1 && \
     npm install --omit=dev \
+                @aws-sdk/client-bedrock-agentcore \
                 @aws-sdk/client-bedrock-runtime \
                 @aws-sdk/client-cognito-identity-provider \
                 @aws-sdk/client-s3 \
@@ -42,6 +48,9 @@ RUN cd /app && npm init -y > /dev/null 2>&1 && \
                 @aws-sdk/client-dynamodb \
                 @aws-sdk/client-sts \
                 @aws-sdk/lib-dynamodb \
+                playwright-core \
+                @aws-sdk/s3-request-presigner \
+                @aws-sdk/client-cloudwatch-logs \
                 ws
 
 # Pre-warm V8 compile cache for heavy AWS SDK modules.
@@ -103,6 +112,7 @@ COPY agentcore-contract.js /app/agentcore-contract.js
 COPY agentcore-proxy.js /app/agentcore-proxy.js
 COPY lightweight-agent.js /app/lightweight-agent.js
 COPY workspace-sync.js /app/workspace-sync.js
+COPY cloudwatch-logger.js /app/cloudwatch-logger.js
 COPY scoped-credentials.js /app/scoped-credentials.js
 COPY force-ipv4.js /app/force-ipv4.js
 
@@ -122,6 +132,10 @@ RUN chmod +x /skills/clawhub-manage/*.js
 # Copy API key management skill (dual-mode: native file + Secrets Manager)
 COPY skills/api-keys /skills/api-keys
 RUN chmod +x /skills/api-keys/*.js
+
+# Copy AgentCore browser skill (headless Chromium browsing)
+COPY skills/agentcore-browser /skills/agentcore-browser
+RUN chmod +x /skills/agentcore-browser/*.js
 
 # Copy project instructions (CLAUDE.md) so the agent knows about its skills
 COPY CLAUDE.md /app/CLAUDE.md

--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -358,6 +358,11 @@ function writeOpenClawConfig() {
     },
     tools: {
       profile: "full",
+      exec: {
+        host: "gateway",  // Run on container host — microVM provides isolation, no Docker sandbox
+        security: "full", // Full shell access; container is already isolated
+        ask: "off",       // Headless container — no approval UI
+      },
       deny: [
         "write", // Local writes don't persist — use S3 skill instead
         "edit", // Local edits are ephemeral — use S3 skill instead

--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -1629,20 +1629,69 @@ const server = http.createServer(async (req, res) => {
                 );
                 responseText = "";
               }
-              // If bridge returned empty (OpenClaw sent no content), fall back to
-              // lightweight agent so the user always gets a real AI response.
+              // If bridge returned empty (OpenClaw sent no content), check whether
+              // OpenClaw is mid-run before falling back to lightweight agent.
+              // A tool-call-only response or concurrent subagent task can produce
+              // an empty bridge response that is NOT a failure.
               if (!responseText || !responseText.trim()) {
-                console.warn(
-                  "[contract] Bridge returned empty — falling back to lightweight agent",
-                );
+                // Brief retry — transient empty responses resolve quickly
+                await new Promise((r) => setTimeout(r, 300));
+
+                // Probe OpenClaw to see if it is still busy
+                let openclawBusy = false;
                 try {
-                  responseText = await agent.chat(bridgeText, actorId, Date.now() + 30000);
-                } catch (agentErr) {
-                  responseText =
-                    "I'm having trouble right now. Please try again in a moment.";
-                  console.error(
-                    `[contract] Lightweight agent fallback error: ${agentErr.message}`,
+                  const pingData = await new Promise((resolve, reject) => {
+                    const pingReq = http.get(
+                      `http://127.0.0.1:${OPENCLAW_PORT}`,
+                      (pingRes) => {
+                        let data = "";
+                        pingRes.on("data", (c) => (data += c));
+                        pingRes.on("end", () => resolve(data));
+                      },
+                    );
+                    pingReq.on("error", reject);
+                    pingReq.setTimeout(2000, () => {
+                      pingReq.destroy();
+                      reject(new Error("ping timeout"));
+                    });
+                  });
+                  // OpenClaw may return JSON with activeTasks count
+                  try {
+                    const parsed = JSON.parse(pingData);
+                    if (parsed.activeTasks > 0) openclawBusy = true;
+                  } catch {
+                    // Non-JSON response — OpenClaw is alive but format unknown
+                  }
+                } catch {
+                  // OpenClaw not responding — not busy, allow fallback
+                }
+
+                // Also treat a still-running process (no exit code) as busy
+                if (openclawExitCode === null) openclawBusy = true;
+
+                if (openclawBusy) {
+                  console.log(
+                    "[contract] Bridge returned empty but OpenClaw is mid-run — returning busy message",
                   );
+                  responseText =
+                    "I'm still working on your previous request — check back in a moment.";
+                } else {
+                  console.warn(
+                    "[contract] Bridge returned empty — falling back to lightweight agent",
+                  );
+                  try {
+                    responseText = await agent.chat(
+                      bridgeText,
+                      actorId,
+                      Date.now() + 30000,
+                    );
+                  } catch (agentErr) {
+                    responseText =
+                      "I'm having trouble right now. Please try again in a moment.";
+                    console.error(
+                      `[contract] Lightweight agent fallback error: ${agentErr.message}`,
+                    );
+                  }
                 }
               }
             } else if (proxyReady) {

--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -38,6 +38,10 @@ const OPENCLAW_PORT = 18789;
 // No fallback — container will fail to authenticate WebSocket if not set.
 let GATEWAY_TOKEN = null;
 
+// Telegram bot token — fetched from Secrets Manager eagerly at boot.
+// Used for progressive message streaming (send/edit messages as deltas arrive).
+let TELEGRAM_BOT_TOKEN = null;
+
 // Cognito password secret — fetched from Secrets Manager eagerly at boot.
 // Stored in-process only, never written to process.env.
 let COGNITO_PASSWORD_SECRET = null;
@@ -151,6 +155,32 @@ async function prefetchSecrets() {
     if (resp.SecretString) {
       COGNITO_PASSWORD_SECRET = resp.SecretString;
       console.log("[contract] Cognito password secret pre-fetched");
+    }
+  }
+
+  const telegramSecretId = process.env.TELEGRAM_CHANNEL_SECRET_ID;
+  if (telegramSecretId) {
+    try {
+      const resp = await smClient.send(
+        new GetSecretValueCommand({ SecretId: telegramSecretId }),
+      );
+      if (resp.SecretString) {
+        // Secret may be a plain token or JSON with bot_token/token key
+        try {
+          const parsed = JSON.parse(resp.SecretString);
+          TELEGRAM_BOT_TOKEN =
+            parsed.bot_token || parsed.token || resp.SecretString;
+        } catch {
+          TELEGRAM_BOT_TOKEN = resp.SecretString;
+        }
+        console.log(
+          "[contract] Telegram bot token pre-fetched from Secrets Manager",
+        );
+      }
+    } catch (err) {
+      console.warn(
+        `[contract] Telegram secret fetch failed (streaming disabled): ${err.message}`,
+      );
     }
   }
 
@@ -1073,6 +1103,127 @@ function extractTextFromContent(content) {
   return "";
 }
 
+// ---------------------------------------------------------------------------
+// Telegram progressive streaming helpers
+// ---------------------------------------------------------------------------
+
+const https = require("https");
+
+/**
+ * Call the Telegram Bot API. Returns parsed JSON response.
+ */
+function telegramApiCall(method, body) {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const req = https.request(
+      {
+        hostname: "api.telegram.org",
+        path: `/bot${TELEGRAM_BOT_TOKEN}/${method}`,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(payload),
+        },
+        timeout: 10000,
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(data));
+          } catch {
+            resolve({ ok: false, description: data });
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("Telegram API timeout"));
+    });
+    req.end(payload);
+  });
+}
+
+/**
+ * Create a progressive Telegram streamer for a given chat.
+ * Returns an { onDelta, finalize } pair.
+ *
+ * onDelta(text): called with cumulative response text on each WS delta.
+ *   - First call (>20 chars): sends initial message with "..." suffix.
+ *   - Subsequent calls (throttled to every 3s): edits the message.
+ * finalize(text): final edit without "..." suffix.
+ */
+function createTelegramStreamer(chatId) {
+  let messageId = null;
+  let lastEditTime = 0;
+  let lastSentText = "";
+  const MIN_EDIT_INTERVAL_MS = 3000;
+  const MIN_INITIAL_CHARS = 20;
+
+  const sendOrEdit = async (text, isFinal) => {
+    const displayText = isFinal ? text : text + " ...";
+    // Avoid editing if text hasn't changed
+    if (displayText === lastSentText && !isFinal) return;
+
+    try {
+      if (!messageId) {
+        // First message
+        const resp = await telegramApiCall("sendMessage", {
+          chat_id: chatId,
+          text: displayText,
+        });
+        if (resp.ok && resp.result?.message_id) {
+          messageId = resp.result.message_id;
+          lastSentText = displayText;
+          lastEditTime = Date.now();
+          console.log(
+            `[telegram-stream] Initial message sent: msg_id=${messageId}`,
+          );
+        }
+      } else {
+        // Edit existing message
+        const resp = await telegramApiCall("editMessageText", {
+          chat_id: chatId,
+          message_id: messageId,
+          text: displayText,
+        });
+        if (resp.ok) {
+          lastSentText = displayText;
+          lastEditTime = Date.now();
+        }
+      }
+    } catch (err) {
+      console.warn(`[telegram-stream] API error: ${err.message}`);
+    }
+  };
+
+  const onDelta = (text) => {
+    if (!text || text.length < MIN_INITIAL_CHARS) return;
+    const now = Date.now();
+    if (!messageId) {
+      // Send initial message immediately
+      sendOrEdit(text, false);
+    } else if (now - lastEditTime >= MIN_EDIT_INTERVAL_MS) {
+      sendOrEdit(text, false);
+    }
+    // Otherwise skip — throttled
+  };
+
+  const finalize = async (text) => {
+    if (!text) return { messageId };
+    if (messageId) {
+      await sendOrEdit(text, true);
+    }
+    // If no message was ever sent (response too short), don't send — let Router handle it
+    return { messageId };
+  };
+
+  return { onDelta, finalize };
+}
+
 /**
  * Process the message queue serially to prevent concurrent WebSocket race conditions.
  */
@@ -1081,13 +1232,13 @@ async function processMessageQueue() {
   processingMessage = true;
 
   while (messageQueue.length > 0) {
-    const { message, resolve, reject } = messageQueue.shift();
+    const { message, onDelta, resolve, reject } = messageQueue.shift();
     console.log(
       `[contract] Processing queued message (${messageQueue.length} remaining)`,
     );
 
     try {
-      const response = await bridgeMessage(message, 560000);
+      const response = await bridgeMessage(message, 620000, onDelta);
       resolve(response);
     } catch (err) {
       reject(err);
@@ -1099,10 +1250,12 @@ async function processMessageQueue() {
 
 /**
  * Enqueue a message and wait for its response (serialized processing).
+ * @param {string} message - The message to send
+ * @param {function} [onDelta] - Optional callback invoked with cumulative text on each delta
  */
-function enqueueMessage(message) {
+function enqueueMessage(message, onDelta) {
   return new Promise((resolve, reject) => {
-    messageQueue.push({ message, resolve, reject });
+    messageQueue.push({ message, onDelta, resolve, reject });
     console.log(
       `[contract] Message enqueued (queue length: ${messageQueue.length})`,
     );
@@ -1114,8 +1267,11 @@ function enqueueMessage(message) {
 
 /**
  * Bridge a chat message to OpenClaw via WebSocket and collect the response.
+ * @param {string} message - The message to send
+ * @param {number} timeoutMs - Timeout in milliseconds
+ * @param {function} [onDelta] - Optional callback invoked with cumulative text on each delta
  */
-async function bridgeMessage(message, timeoutMs = 560000) {
+async function bridgeMessage(message, timeoutMs = 620000, onDelta) {
   const { randomUUID } = require("crypto");
   return new Promise((resolve) => {
     const wsUrl = `ws://127.0.0.1:${OPENCLAW_PORT}`;
@@ -1248,7 +1404,10 @@ async function bridgeMessage(message, timeoutMs = 560000) {
 
         if (payload.state === "delta") {
           const text = extractFromPayload(payload);
-          if (text) responseText = text; // Delta replaces (accumulates progressively)
+          if (text) {
+            responseText = text; // Delta replaces (accumulates progressively)
+            if (onDelta) onDelta(text);
+          }
           return;
         }
 
@@ -1613,6 +1772,26 @@ const server = http.createServer(async (req, res) => {
 
           const bridgeText = buildBridgeText(message);
 
+          // Set up progressive Telegram streaming if applicable
+          let telegramStreamer = null;
+          if (
+            TELEGRAM_BOT_TOKEN &&
+            channel === "telegram" &&
+            actorId
+          ) {
+            // actorId is "telegram:123456789" — extract numeric chat ID
+            const chatId = actorId.split(":")[1];
+            if (chatId) {
+              telegramStreamer = createTelegramStreamer(chatId);
+              console.log(
+                `[contract] Telegram streaming enabled for chat_id=${chatId}`,
+              );
+            }
+          }
+          const onDelta = telegramStreamer
+            ? telegramStreamer.onDelta
+            : undefined;
+
           // Track active task to prevent idle termination during chat processing
           lastActivityTime = Math.floor(Date.now() / 1000);
           activeTaskCount++;
@@ -1622,7 +1801,7 @@ const server = http.createServer(async (req, res) => {
             if (openclawReady) {
               // Full OpenClaw path — WebSocket bridge
               try {
-                responseText = await enqueueMessage(bridgeText);
+                responseText = await enqueueMessage(bridgeText, onDelta);
               } catch (bridgeErr) {
                 console.error(
                   `[contract] Bridge error, falling back to shim: ${bridgeErr.message}`,
@@ -1698,7 +1877,7 @@ const server = http.createServer(async (req, res) => {
               // Warm-up shim path — lightweight agent via proxy
               console.log("[contract] Routing via lightweight agent (warm-up)");
               try {
-                responseText = await agent.chat(bridgeText, actorId, Date.now() + 560000);
+                responseText = await agent.chat(bridgeText, actorId, Date.now() + 620000);
               } catch (agentErr) {
                 responseText = `I'm having trouble right now. Please try again in a moment.`;
                 console.error(
@@ -1716,12 +1895,31 @@ const server = http.createServer(async (req, res) => {
           // Belt-and-suspenders: strip any remaining content-block JSON wrappers
           if (responseText) responseText = extractTextFromContent(responseText);
 
+          // Finalize Telegram streaming (final edit without "..." suffix)
+          let telegramStreamed = false;
+          if (telegramStreamer && responseText) {
+            try {
+              const result = await telegramStreamer.finalize(responseText);
+              if (result.messageId) {
+                telegramStreamed = true;
+                console.log(
+                  `[contract] Telegram streaming finalized: msg_id=${result.messageId}`,
+                );
+              }
+            } catch (err) {
+              console.warn(
+                `[contract] Telegram streaming finalize error: ${err.message}`,
+              );
+            }
+          }
+
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(
             JSON.stringify({
               response: responseText,
               userId: currentUserId,
               sessionId: payload.sessionId || null,
+              streamed: telegramStreamed || undefined,
             }),
           );
           return;

--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -39,7 +39,7 @@ const OPENCLAW_PORT = 18789;
 let GATEWAY_TOKEN = null;
 
 // Telegram bot token — fetched from Secrets Manager eagerly at boot.
-// Used for progressive message streaming (send/edit messages as deltas arrive).
+// Used for typing indicator during processing + single final message delivery.
 let TELEGRAM_BOT_TOKEN = null;
 
 // Cognito password secret — fetched from Secrets Manager eagerly at boot.
@@ -1148,77 +1148,64 @@ function telegramApiCall(method, body) {
 }
 
 /**
- * Create a progressive Telegram streamer for a given chat.
- * Returns an { onDelta, finalize } pair.
+ * Create a Telegram streamer that shows "typing..." indicator while working,
+ * then sends ONE clean final message when done. No intermediate edits.
  *
- * onDelta(text): called with cumulative response text on each WS delta.
- *   - First call (>20 chars): sends initial message with "..." suffix.
- *   - Subsequent calls (throttled to every 3s): edits the message.
- * finalize(text): final edit without "..." suffix.
+ * onDelta(text): starts a typing indicator loop (sendChatAction every 5s).
+ * finalize(text): stops the typing loop and sends a single sendMessage.
  */
 function createTelegramStreamer(chatId) {
-  let messageId = null;
-  let lastEditTime = 0;
-  let lastSentText = "";
-  const MIN_EDIT_INTERVAL_MS = 8000;
-  const MIN_INITIAL_CHARS = 60;
+  let typingInterval = null;
+  let typingStarted = false;
 
-  const sendOrEdit = async (text, isFinal) => {
-    const displayText = isFinal ? text : text + " ...";
-    // Avoid editing if text hasn't changed
-    if (displayText === lastSentText && !isFinal) return;
-
+  const sendTyping = async () => {
     try {
-      if (!messageId) {
-        // First message
-        const resp = await telegramApiCall("sendMessage", {
-          chat_id: chatId,
-          text: displayText,
-        });
-        if (resp.ok && resp.result?.message_id) {
-          messageId = resp.result.message_id;
-          lastSentText = displayText;
-          lastEditTime = Date.now();
-          console.log(
-            `[telegram-stream] Initial message sent: msg_id=${messageId}`,
-          );
-        }
-      } else {
-        // Edit existing message
-        const resp = await telegramApiCall("editMessageText", {
-          chat_id: chatId,
-          message_id: messageId,
-          text: displayText,
-        });
-        if (resp.ok) {
-          lastSentText = displayText;
-          lastEditTime = Date.now();
-        }
-      }
+      await telegramApiCall("sendChatAction", {
+        chat_id: chatId,
+        action: "typing",
+      });
     } catch (err) {
-      console.warn(`[telegram-stream] API error: ${err.message}`);
+      console.warn(`[telegram-stream] Typing indicator error: ${err.message}`);
+    }
+  };
+
+  const startTypingLoop = () => {
+    if (typingStarted) return;
+    typingStarted = true;
+    sendTyping();
+    typingInterval = setInterval(sendTyping, 5000);
+    console.log(`[telegram-stream] Typing indicator started for chat_id=${chatId}`);
+  };
+
+  const stopTypingLoop = () => {
+    if (typingInterval) {
+      clearInterval(typingInterval);
+      typingInterval = null;
     }
   };
 
   const onDelta = (text) => {
-    if (!text || text.length < MIN_INITIAL_CHARS) return;
-    const now = Date.now();
-    if (!messageId) {
-      // Send initial message immediately
-      sendOrEdit(text, false);
-    } else if (now - lastEditTime >= MIN_EDIT_INTERVAL_MS) {
-      sendOrEdit(text, false);
-    }
-    // Otherwise skip — throttled
+    if (!text || text.length < 60) return;
+    startTypingLoop();
   };
 
   const finalize = async (text) => {
-    if (!text) return { messageId };
-    if (messageId) {
-      await sendOrEdit(text, true);
+    stopTypingLoop();
+    if (!text) return { messageId: null };
+    try {
+      const resp = await telegramApiCall("sendMessage", {
+        chat_id: chatId,
+        text,
+      });
+      const messageId = resp.ok ? resp.result?.message_id : null;
+      if (messageId) {
+        console.log(`[telegram-stream] Final message sent: msg_id=${messageId}`);
+      }
+      return { messageId };
+    } catch (err) {
+      console.warn(`[telegram-stream] Final send error: ${err.message}`);
+      return { messageId: null };
     }
-    // If no message was ever sent (response too short), don't send — let Router handle it
-    return { messageId };
   };
 
   return { onDelta, finalize };

--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -898,7 +898,13 @@ async function init(userId, actorId, channel) {
     };
     proxyProcess = spawn("node", ["/app/agentcore-proxy.js"], {
       env: proxyEnv,
-      stdio: "inherit",
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    proxyProcess.stdout.on("data", (d) => {
+      d.toString().split("\n").filter(Boolean).forEach(line => console.log(`[proxy:out] ${line}`));
+    });
+    proxyProcess.stderr.on("data", (d) => {
+      d.toString().split("\n").filter(Boolean).forEach(line => console.error(`[proxy:err] ${line}`));
     });
     proxyProcess.on("exit", (code) => {
       console.log(`[contract] Proxy exited with code ${code}`);

--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -1160,8 +1160,8 @@ function createTelegramStreamer(chatId) {
   let messageId = null;
   let lastEditTime = 0;
   let lastSentText = "";
-  const MIN_EDIT_INTERVAL_MS = 3000;
-  const MIN_INITIAL_CHARS = 20;
+  const MIN_EDIT_INTERVAL_MS = 8000;
+  const MIN_INITIAL_CHARS = 60;
 
   const sendOrEdit = async (text, isFinal) => {
     const displayText = isFinal ? text : text + " ...";

--- a/bridge/agentcore-proxy.js
+++ b/bridge/agentcore-proxy.js
@@ -1250,37 +1250,24 @@ async function invokeBedrockStreaming(
         // Tool use start
         if (event.contentBlockStart?.start?.toolUse) {
           const tu = event.contentBlockStart.start.toolUse;
-          const blockIdx = event.contentBlockStart.contentBlockIndex ?? -1;
-          console.log(`[proxy-debug] TOOL_START name=${tu.name} blockIdx=${blockIdx} id=${tu.toolUseId}`);
           currentToolUse = { id: tu.toolUseId, name: tu.name };
           currentToolInput = "";
-          currentToolBlockIndex = blockIdx;
-        }
-
-        // Text block start (debug)
-        if (event.contentBlockStart && !event.contentBlockStart?.start?.toolUse) {
-          const blockIdx = event.contentBlockStart.contentBlockIndex ?? -1;
-          console.log(`[proxy-debug] TEXT_START blockIdx=${blockIdx}`);
+          currentToolBlockIndex = event.contentBlockStart.contentBlockIndex ?? -1;
         }
 
         // Tool use input delta
         if (event.contentBlockDelta?.delta?.toolUse) {
           const inputChunk = event.contentBlockDelta.delta.toolUse.input || "";
-          console.log(`[proxy-debug] TOOL_DELTA blockIdx=${event.contentBlockDelta.contentBlockIndex} chunkLen=${inputChunk.length} accumulated=${currentToolInput.length + inputChunk.length}`);
           currentToolInput += inputChunk;
         }
 
         // Content block stop — finalize tool use only when the stopped block matches the tool block
         const stopBlockIndex = event.contentBlockStop?.contentBlockIndex ?? -1;
-        if (event.contentBlockStop) {
-          console.log(`[proxy-debug] BLOCK_STOP stopIdx=${stopBlockIndex} toolBlockIdx=${currentToolBlockIndex} hasToolUse=${!!currentToolUse} inputLen=${currentToolInput.length}`);
-        }
         if (event.contentBlockStop && currentToolUse && stopBlockIndex === currentToolBlockIndex) {
           let parsedInput = {};
           try {
             parsedInput = JSON.parse(currentToolInput);
           } catch {}
-          console.log(`[proxy-debug] FINALIZE name=${currentToolUse.name} inputLen=${currentToolInput.length} parsedKeys=${Object.keys(parsedInput).join(",")}`);
           const toolCallIndex = toolCalls.length;
           toolCalls.push({
             id: currentToolUse.id,

--- a/bridge/agentcore-proxy.js
+++ b/bridge/agentcore-proxy.js
@@ -1085,7 +1085,7 @@ async function invokeBedrock(messages, systemTextOverride, toolConfig, requested
     modelId,
     messages: bedrockMessages,
     system: [{ text: finalSystemText }],
-    inferenceConfig: { maxTokens: 2048, temperature: 0.7 },
+    inferenceConfig: { maxTokens: 16384, temperature: 0.7 },
     ...(guardrailConfig && { guardrailConfig }),
   };
   if (toolConfig) params.toolConfig = toolConfig;
@@ -1184,7 +1184,7 @@ async function invokeBedrockStreaming(
     modelId,
     messages: bedrockMessages,
     system: [{ text: finalSystemText }],
-    inferenceConfig: { maxTokens: 2048, temperature: 0.7 },
+    inferenceConfig: { maxTokens: 16384, temperature: 0.7 },
     ...(guardrailConfig && { guardrailConfig }),
   };
   if (toolConfig) params.toolConfig = toolConfig;

--- a/bridge/agentcore-proxy.js
+++ b/bridge/agentcore-proxy.js
@@ -1250,23 +1250,37 @@ async function invokeBedrockStreaming(
         // Tool use start
         if (event.contentBlockStart?.start?.toolUse) {
           const tu = event.contentBlockStart.start.toolUse;
+          const blockIdx = event.contentBlockStart.contentBlockIndex ?? -1;
+          console.log(`[proxy-debug] TOOL_START name=${tu.name} blockIdx=${blockIdx} id=${tu.toolUseId}`);
           currentToolUse = { id: tu.toolUseId, name: tu.name };
           currentToolInput = "";
-          currentToolBlockIndex = event.contentBlockStart.contentBlockIndex ?? -1;
+          currentToolBlockIndex = blockIdx;
+        }
+
+        // Text block start (debug)
+        if (event.contentBlockStart && !event.contentBlockStart?.start?.toolUse) {
+          const blockIdx = event.contentBlockStart.contentBlockIndex ?? -1;
+          console.log(`[proxy-debug] TEXT_START blockIdx=${blockIdx}`);
         }
 
         // Tool use input delta
         if (event.contentBlockDelta?.delta?.toolUse) {
-          currentToolInput += event.contentBlockDelta.delta.toolUse.input || "";
+          const inputChunk = event.contentBlockDelta.delta.toolUse.input || "";
+          console.log(`[proxy-debug] TOOL_DELTA blockIdx=${event.contentBlockDelta.contentBlockIndex} chunkLen=${inputChunk.length} accumulated=${currentToolInput.length + inputChunk.length}`);
+          currentToolInput += inputChunk;
         }
 
         // Content block stop — finalize tool use only when the stopped block matches the tool block
         const stopBlockIndex = event.contentBlockStop?.contentBlockIndex ?? -1;
+        if (event.contentBlockStop) {
+          console.log(`[proxy-debug] BLOCK_STOP stopIdx=${stopBlockIndex} toolBlockIdx=${currentToolBlockIndex} hasToolUse=${!!currentToolUse} inputLen=${currentToolInput.length}`);
+        }
         if (event.contentBlockStop && currentToolUse && stopBlockIndex === currentToolBlockIndex) {
           let parsedInput = {};
           try {
             parsedInput = JSON.parse(currentToolInput);
           } catch {}
+          console.log(`[proxy-debug] FINALIZE name=${currentToolUse.name} inputLen=${currentToolInput.length} parsedKeys=${Object.keys(parsedInput).join(",")}`);
           const toolCallIndex = toolCalls.length;
           toolCalls.push({
             id: currentToolUse.id,

--- a/bridge/agentcore-proxy.js
+++ b/bridge/agentcore-proxy.js
@@ -1199,6 +1199,7 @@ async function invokeBedrockStreaming(
   const toolCalls = [];
   let currentToolUse = null;
   let currentToolInput = "";
+  let currentToolBlockIndex = -1;
 
   let lastError;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
@@ -1213,6 +1214,7 @@ async function invokeBedrockStreaming(
         toolCalls.length = 0;
         currentToolUse = null;
         currentToolInput = "";
+        currentToolBlockIndex = -1;
       }
 
       const response = await client.send(new ConverseStreamCommand(params));
@@ -1250,6 +1252,7 @@ async function invokeBedrockStreaming(
           const tu = event.contentBlockStart.start.toolUse;
           currentToolUse = { id: tu.toolUseId, name: tu.name };
           currentToolInput = "";
+          currentToolBlockIndex = event.contentBlockStart.contentBlockIndex ?? -1;
         }
 
         // Tool use input delta
@@ -1257,8 +1260,9 @@ async function invokeBedrockStreaming(
           currentToolInput += event.contentBlockDelta.delta.toolUse.input || "";
         }
 
-        // Content block stop — finalize tool use if one was in progress
-        if (event.contentBlockStop && currentToolUse) {
+        // Content block stop — finalize tool use only when the stopped block matches the tool block
+        const stopBlockIndex = event.contentBlockStop?.contentBlockIndex ?? -1;
+        if (event.contentBlockStop && currentToolUse && stopBlockIndex === currentToolBlockIndex) {
           let parsedInput = {};
           try {
             parsedInput = JSON.parse(currentToolInput);
@@ -1301,6 +1305,7 @@ async function invokeBedrockStreaming(
           res.write(`data: ${JSON.stringify(toolChunk)}\n\n`);
           currentToolUse = null;
           currentToolInput = "";
+          currentToolBlockIndex = -1;
         }
 
         if (event.metadata?.usage) {

--- a/lambda/router/index.py
+++ b/lambda/router/index.py
@@ -1487,6 +1487,11 @@ def handle_telegram(body):
     response_text = _extract_text_from_content_blocks(response_text)
     logger.info("Response to send (len=%d): %s", len(response_text), response_text[:2000])
 
+    # If contract already streamed progressively to Telegram, skip duplicate send
+    if result.get("streamed"):
+        logger.info("Telegram response already streamed by contract — skipping send to chat_id=%s", chat_id)
+        return
+
     # Send response (split if > 4096 chars for Telegram limit)
     if len(response_text) <= 4096:
         send_telegram_message(chat_id, response_text, token)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -181,6 +181,7 @@ read_cdk_outputs() {
     --output text)
 
   COGNITO_PASSWORD_SECRET_ID="openclaw/cognito-password-secret"
+  TELEGRAM_CHANNEL_SECRET_ID="openclaw/channels/telegram"
 
   CMK_ARN=$(aws cloudformation describe-stacks \
     --stack-name OpenClawSecurity --region "$REGION" \
@@ -287,7 +288,8 @@ phase2_toolkit() {
     --env "EVENTBRIDGE_ROLE_ARN=arn:aws:iam::${ACCOUNT}:role/openclaw-cron-scheduler-role-${REGION}" \
     --env "IDENTITY_TABLE_NAME=openclaw-identity" \
     --env "CRON_LEAD_TIME_MINUTES=$CRON_LEAD_TIME" \
-    --env "SUBAGENT_BEDROCK_MODEL_ID=$SUBAGENT_MODEL_ID"
+    --env "SUBAGENT_BEDROCK_MODEL_ID=$SUBAGENT_MODEL_ID" \
+    --env "TELEGRAM_CHANNEL_SECRET_ID=$TELEGRAM_CHANNEL_SECRET_ID"
 
   # Read runtime ID and endpoint ID from toolkit
   echo "--- Reading runtime info ---"

--- a/stacks/agentcore_stack.py
+++ b/stacks/agentcore_stack.py
@@ -128,6 +128,7 @@ class AgentCoreStack(Stack):
                 resources=[
                     f"arn:aws:secretsmanager:{region}:{account}:secret:openclaw/gateway-token-*",
                     f"arn:aws:secretsmanager:{region}:{account}:secret:openclaw/cognito-password-secret-*",
+                    f"arn:aws:secretsmanager:{region}:{account}:secret:openclaw/channels/telegram-*",
                 ],
             )
         )
@@ -386,6 +387,7 @@ class AgentCoreStack(Stack):
                         "Resource::arn:aws:bedrock:*::inference-profile/*",
                         f"Resource::arn:aws:secretsmanager:{region}:{account}:secret:openclaw/gateway-token-*",
                         f"Resource::arn:aws:secretsmanager:{region}:{account}:secret:openclaw/cognito-password-secret-*",
+                        f"Resource::arn:aws:secretsmanager:{region}:{account}:secret:openclaw/channels/telegram-*",
                         "Resource::*",
                         f"Resource::arn:aws:logs:{region}:{account}:log-group:/openclaw/*",
                         f"Resource::arn:aws:logs:{region}:{account}:log-group:/openclaw/*:*",


### PR DESCRIPTION
## What this PR fixes

This PR contains all production fixes shipped on 2026-03-21 to restore the deployed OpenClaw-on-AgentCore bot to a working state, plus Telegram UX improvements.

### 🔴 Root cause: `maxTokens: 2048` causing empty exec calls
Large exec commands (e.g. writing dashboard HTML) exceeded the 2048-token output cap. The tool call input was truncated mid-stream, producing empty `{}` args. OpenClaw recorded these as failed exec calls, the model learned the pattern from context, and all subsequent exec calls became empty — poisoning the session. **Fix: increased to 16384.**

### 🔴 exec tool completely non-functional
`tools.exec.host` defaulted to `"sandbox"` but `sandbox.mode: "off"` causes fail-closed behaviour — all exec calls completed in 3–6ms with nothing executed. **Fix: set `host: "gateway"`, `security: "full"`, `ask: "off"`.**

### 🔴 Container crash on startup
`cloudwatch-logger.js` was missing from the Dockerfile. Also pins `openclaw@2026.3.8` and `clawhub@0.8.0` to prevent unexpected breakage from upstream updates.

### 🟡 WebSocket timeout cutting off long tasks
Contract WS timeout was 560s — 40s shorter than the agent run timeout (600s). Long tasks were cut off before completion. **Fix: increased to 620s.**

### 🟡 Proxy premature tool call finalization
On mixed text+tool responses, a `contentBlockStop` for a text block was incorrectly finalizing a tool call in a different content block. **Fix: track `currentToolBlockIndex` and only finalize when stop event matches.**

### 🟡 Lightweight agent fallback interrupting active tasks
When the bridge returned an empty response (tool-call-only or concurrent subagent), the contract immediately fell back to the lightweight agent shim — interrupting in-progress work. **Fix: probe OpenClaw first; return "still working" if active.**

### 🟢 Telegram UX: typing indicator + single final message
Instead of spammy progressive edits, the contract now shows Telegrams typing indicator during processing and sends one final message when the response is complete. Eliminates the "message flickering" problem.

### 🟢 CloudWatch visibility
Proxy stdout is now piped through the contract logger so all proxy output (Bedrock calls, errors, tool events) appears in CloudWatch logs.

### 🧹 Cleanup
Removed proxy debug logging (`STREAM_EVENT:`, `TOOL_EVENT:`, etc.) and dead streaming constants (`STREAM_CHUNK`, `STREAM_END`, `STREAM_ERROR`) that were left over from debugging.

## Commits

| Commit | Description |
|--------|-------------|
| `a4bfb51` | fix(contract): replace streaming edits with typing indicator + single final message |
| `c1e3e28` | debug(proxy): add stream event logging to diagnose empty exec args |
| `df56e18` | fix(contract): pipe proxy stdout through contract logger for CloudWatch visibility |
| `7efee7b` | fix(proxy): increase maxTokens from 2048 to 16384 to prevent tool call truncation |
| `af538a7` | chore: remove proxy debug logging and dead streaming constants |
| + earlier commits | exec host fix, Dockerfile fix, version pinning, WS timeout, tool block index tracking, lightweight agent fallback guard |

## Test plan

- [x] Verify exec tool works (write a file, run a command)
- [x] Verify long tasks complete without WS timeout
- [x] Verify Telegram shows typing indicator (no message flickering)
- [x] Verify proxy logs appear in CloudWatch
- [x] Verify lightweight agent doesn't interrupt active OpenClaw tasks