### PR TITLE
fix: remove unregistered PyPI package bedrock-agentcore-toolkit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 aws-cdk-lib>=2.170.0,<3.0.0
 constructs>=10.0.0,<11.0.0
 cdk-nag>=2.28.0,<3.0.0
-bedrock-agentcore-toolkit>=1.0.0


### PR DESCRIPTION
Remove `bedrock-agentcore-toolkit` from `requirements.txt` — this package is not used by the sample.
