### PR TITLE
feat(runtime): add AgentCore Session Storage for workspace persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ OpenClaw on AgentCore Runtime — a multi-channel AI messaging bot (Telegram, Sl
 - **Tools & Skills**: Built-in tool groups (full profile) + 5 ClawHub skills + 5 custom skills (S3 user files, EventBridge cron, ClawHub manage, API keys, agentcore-browser) + 2 built-in shim tools (web_fetch, web_search)
 - **Scheduling**: EventBridge Scheduler for recurring tasks — cron executor Lambda warms sessions and delivers responses to channels
 - **Per-User File Storage**: S3-backed per-user file isolation via custom `s3-user-files` skill
-- **Workspace Persistence**: .openclaw/ directory synced to/from S3 per user
-- **AI Model**: MiniMax M2.1 via Bedrock ConverseStream (configurable via `default_model_id` in `cdk.json`, default `minimax.minimax-m2.1`)
+- **Workspace Persistence**: AgentCore Session Storage (primary, `/mnt/workspace`) + S3 backup (5 min). `.openclaw/` symlinked to session storage mount; S3 backup restores on new sessions or version updates. **Note**: `update-agent-runtime` clears session storage — S3 backup auto-restores
+- **AI Model**: Claude Opus 4.6 via Bedrock ConverseStream (configurable via `default_model_id` in `cdk.json`, default `global.anthropic.claude-opus-4-6-v1`)
 - **Identity**: DynamoDB identity table (channel→user mapping, cross-channel binding) + Cognito User Pool
 - **Observability**: CloudWatch dashboards + alarms, Bedrock invocation logging
 - **Token Monitoring**: Lambda + DynamoDB (single-table) + CloudWatch custom metrics
@@ -496,7 +496,7 @@ sudo docker push $ACCOUNT.dkr.ecr.$CDK_DEFAULT_REGION.amazonaws.com/bedrock-agen
 |---|---|---|
 | `account` | (empty) | AWS account ID. Falls back to `CDK_DEFAULT_ACCOUNT` |
 | `region` | `us-west-2` | AWS region. Falls back to `CDK_DEFAULT_REGION` |
-| `default_model_id` | `global.anthropic.claude-opus-4-6-v1` | Bedrock model ID. The `global.` prefix routes to any available region |
+| `default_model_id` | `global.anthropic.claude-opus-4-6-v1` | Bedrock model ID for Claude Opus 4.6. The `global.` prefix routes to any available region |
 | `runtime_id` | (empty) | AgentCore Runtime ID from Starter Toolkit. Populated by deploy script after `agentcore deploy` |
 | `runtime_endpoint_id` | (empty) | AgentCore Runtime Endpoint ID. Typically `DEFAULT` when using Starter Toolkit |
 | `image_version` | `1` | Bridge container version tag. Bump to force container redeploy |
@@ -528,7 +528,8 @@ sudo docker push $ACCOUNT.dkr.ecr.$CDK_DEFAULT_REGION.amazonaws.com/bedrock-agen
    - Configure workspace-sync with scoped credentials
    - Start `agentcore-proxy.js` (port 18790) with `USER_ID`/`CHANNEL` env vars
    - Start OpenClaw gateway (port 18789) with scoped credentials env (no container credentials)
-   - Restore `.openclaw/` from S3 via `workspace-sync.js` in background
+   - Set up session storage symlink (`~/.openclaw` → `/mnt/workspace/.openclaw`)
+   - If session storage empty: restore `.openclaw/` from S3 via `workspace-sync.js`
    - Start credential refresh timer (45 min interval)
    - If `BROWSER_IDENTIFIER` set: create browser session via AgentCore Browser API, write session file to `/tmp/agentcore-browser-session.json`
    - Wait for proxy only (~5s)
@@ -680,11 +681,17 @@ Only the **first channel identity** needs to be allowlisted. When a user binds a
 - **Security**: S3 key validated against user's namespace prefix + path traversal (`..`) rejection. Format validated against `VALID_BEDROCK_FORMATS` set
 - **Slack prerequisite**: Bot needs `files:read` OAuth scope to download image files
 
-### Workspace Sync
-- **S3 prefix**: `{namespace}/.openclaw/` where `namespace = actorId.replace(/:/g, "_")`
-- **Periodic saves**: Every 5 min (configurable via `WORKSPACE_SYNC_INTERVAL_MS`)
-- **SIGTERM grace**: 10s max for final save before exit (AgentCore gives 15s total)
-- **Skip patterns**: `node_modules/`, `.cache/`, `*.log`, files > 10MB
+### Workspace Persistence (Session Storage + S3 Backup)
+- **Primary**: AgentCore Session Storage — service-managed persistent filesystem mounted at `/mnt/workspace`. Data survives session stop/resume automatically. Configured via `filesystemConfigurations` on the Runtime
+- **Symlink**: `~/.openclaw` → `/mnt/workspace/.openclaw` — created during lazy init, transparent to OpenClaw and all skills
+- **S3 backup**: `workspace-sync.js` continues to run at 5 min interval (unchanged). Backs up to `{namespace}/.openclaw/` in the user files S3 bucket
+- **Restore logic**: On init, if session storage has existing data → skip S3 restore (resumed session). If empty → restore from S3 backup (new session or version update)
+- **Fallback**: If session storage mount not available → full S3 sync mode (5 min interval, existing behavior)
+- **Data lifecycle**: Session storage cleared on 14-day inactivity or runtime version update. S3 backup preserves data across these events
+- **⚠️ Version update clears session storage**: Every `update-agent-runtime` (new container image) resets session storage to empty. S3 backup auto-restores on next session start, but there is a window where the latest changes (since last S3 backup) may be lost. Always ensure S3 backup has run before deploying new versions
+- **VPC permissions**: S3 Gateway Endpoint defaults to allow-all — no policy change needed. Session storage is managed by AgentCore platform (not the execution role), so no IAM changes required
+- **SIGTERM grace**: Platform flushes session storage + 10s for S3 final backup
+- **Skip patterns**: `node_modules/`, `.cache/`, `*.log`, files > 10MB (S3 backup only)
 - **Same S3 bucket**: Uses `S3_USER_FILES_BUCKET` (shared with s3-user-files skill)
 
 ### EventBridge Cron Scheduling

--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -34,6 +34,10 @@ const PORT = 8080;
 const PROXY_PORT = 18790;
 const OPENCLAW_PORT = 18789;
 
+// Session storage mount path (set via filesystemConfigurations on Runtime)
+const SESSION_STORAGE_MOUNT = "/mnt/workspace";
+const OPENCLAW_DIR = process.env.HOME ? `${process.env.HOME}/.openclaw` : "/root/.openclaw";
+
 // Gateway token — fetched from Secrets Manager eagerly at boot.
 // No fallback — container will fail to authenticate WebSocket if not set.
 let GATEWAY_TOKEN = null;
@@ -116,6 +120,56 @@ let processingMessage = false;
  * can pick up cross-channel identity changes (the proxy's env vars are
  * fixed at spawn time and cannot be updated for a running child process).
  */
+/**
+ * Set up symlink from ~/.openclaw to session storage mount.
+ * Returns true if session storage is available and symlink was created.
+ */
+function setupSessionStorageSymlink() {
+  try {
+    // Check if session storage mount exists (only available during invocation)
+    if (!fs.existsSync(SESSION_STORAGE_MOUNT)) {
+      console.log("[contract] Session storage not available at", SESSION_STORAGE_MOUNT);
+      return false;
+    }
+
+    const mountedDir = `${SESSION_STORAGE_MOUNT}/.openclaw`;
+    fs.mkdirSync(mountedDir, { recursive: true });
+
+    // Check existing .openclaw — may be a symlink, directory, or missing
+    let existingType = null;
+    try {
+      const stat = fs.lstatSync(OPENCLAW_DIR);
+      if (stat.isSymbolicLink()) {
+        const target = fs.readlinkSync(OPENCLAW_DIR);
+        if (target === mountedDir) {
+          console.log("[contract] Session storage symlink already in place");
+          return true;
+        }
+        existingType = "symlink";
+        fs.unlinkSync(OPENCLAW_DIR);
+      } else if (stat.isDirectory()) {
+        existingType = "directory";
+        // Copy contents to session storage (cross-device, can't use rename)
+        const { execSync } = require("child_process");
+        execSync(`cp -a ${OPENCLAW_DIR}/. ${mountedDir}/ 2>/dev/null || true`);
+        fs.rmSync(OPENCLAW_DIR, { recursive: true, force: true });
+      } else {
+        existingType = "file";
+        fs.unlinkSync(OPENCLAW_DIR);
+      }
+    } catch {
+      // OPENCLAW_DIR doesn't exist yet — that's fine
+    }
+
+    fs.symlinkSync(mountedDir, OPENCLAW_DIR);
+    console.log(`[contract] Session storage symlink: ${OPENCLAW_DIR} -> ${mountedDir} (was: ${existingType || "missing"})`);
+    return true;
+  } catch (err) {
+    console.warn(`[contract] Session storage setup failed: ${err.message}`);
+    return false;
+  }
+}
+
 function updateIdentityFile(actorId, channel) {
   try {
     fs.writeFileSync(
@@ -974,10 +1028,33 @@ async function init(userId, actorId, channel) {
       scheduleOpenClawRestart(currentNamespace);
     });
 
-    // Restore workspace from S3 (non-blocking, needed for OpenClaw)
-    workspaceSync.restoreWorkspace(namespace).catch((err) => {
-      console.warn(`[contract] Workspace restore failed: ${err.message}`);
-    });
+    // Session storage: symlink .openclaw → /mnt/workspace/.openclaw if available
+    const sessionStorageAvailable = setupSessionStorageSymlink();
+
+    // Restore workspace from S3 if session storage is empty or unavailable
+    if (sessionStorageAvailable) {
+      // Check if session storage .openclaw dir has content (non-empty = resumed session)
+      const mountedOpenclawDir = `${SESSION_STORAGE_MOUNT}/.openclaw`;
+      let hasContent = false;
+      try {
+        const entries = fs.readdirSync(mountedOpenclawDir);
+        hasContent = entries.length > 0;
+      } catch { /* dir doesn't exist yet */ }
+
+      if (hasContent) {
+        console.log("[contract] Session storage has existing data — skipping S3 restore");
+      } else {
+        console.log("[contract] Session storage is empty — restoring from S3 backup");
+        workspaceSync.restoreWorkspace(namespace).catch((err) => {
+          console.warn(`[contract] Workspace restore failed: ${err.message}`);
+        });
+      }
+    } else {
+      // No session storage — use S3 sync as primary (existing behavior)
+      workspaceSync.restoreWorkspace(namespace).catch((err) => {
+        console.warn(`[contract] Workspace restore failed: ${err.message}`);
+      });
+    }
 
     // 2. Wait only for proxy readiness (~5s)
     proxyReady = await waitForPort(PROXY_PORT, "Proxy", 30000, 1000);

--- a/bridge/workspace-sync.js
+++ b/bridge/workspace-sync.js
@@ -327,14 +327,27 @@ async function saveWorkspace(namespace) {
 
 // Periodic save state
 let _saveInterval = null;
+// Backup mode: when session storage is primary, S3 sync becomes a cold backup
+let _backupMode = false;
+// Backup interval: 30 minutes (vs 5 minutes for primary sync)
+const BACKUP_INTERVAL_MS = 30 * 60 * 1000;
+
+/**
+ * Enable or disable backup mode.
+ * In backup mode, periodic saves use a longer interval (30 min)
+ * since session storage handles primary persistence.
+ */
+function setBackupMode(enabled) {
+  _backupMode = enabled;
+  console.log(`[workspace-sync] Backup mode ${enabled ? "enabled" : "disabled"} (session storage is ${enabled ? "primary" : "unavailable"})`);
+}
 
 /**
  * Start periodic workspace saves.
  */
 function startPeriodicSave(namespace, intervalMs) {
-  const interval =
-    intervalMs ||
-    parseInt(process.env.WORKSPACE_SYNC_INTERVAL_MS || "300000", 10);
+  const defaultInterval = parseInt(process.env.WORKSPACE_SYNC_INTERVAL_MS || "300000", 10);
+  const interval = intervalMs || (_backupMode ? BACKUP_INTERVAL_MS : defaultInterval);
   if (_saveInterval) clearInterval(_saveInterval);
 
   _saveInterval = setInterval(() => {
@@ -344,7 +357,7 @@ function startPeriodicSave(namespace, intervalMs) {
   }, interval);
 
   console.log(
-    `[workspace-sync] Periodic save started (every ${interval / 1000}s)`,
+    `[workspace-sync] Periodic save started (every ${interval / 1000}s, mode=${_backupMode ? "backup" : "primary"})`,
   );
 }
 
@@ -368,6 +381,7 @@ module.exports = {
   startPeriodicSave,
   cleanup,
   configureCredentials,
+  setBackupMode,
   getS3Client,
   // Exported for testing
   shouldSkip,

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -291,6 +291,55 @@ phase2_toolkit() {
     --env "SUBAGENT_BEDROCK_MODEL_ID=$SUBAGENT_MODEL_ID" \
     --env "TELEGRAM_CHANNEL_SECRET_ID=$TELEGRAM_CHANNEL_SECRET_ID"
 
+  # --- Configure session storage (not supported by agentcore CLI yet) ---
+  echo "--- Configuring session storage ---"
+  # Read runtime ID early for the update-agent-runtime call
+  local _early_runtime_id
+  _early_runtime_id=$(python3 -c "
+import re
+with open('$PROJECT_DIR/.bedrock_agentcore.yaml') as f:
+    text = f.read()
+m = re.search(r'agent_id:\s*(\S+)', text)
+print(m.group(1) if m else '')
+" 2>/dev/null || echo "")
+
+  if [ -n "$_early_runtime_id" ]; then
+    python3 -c "
+import boto3, json, sys
+
+client = boto3.client('bedrock-agentcore-control', region_name='$REGION')
+
+# Get current runtime config to preserve all fields
+rt = client.get_agent_runtime(agentRuntimeId='$_early_runtime_id')
+
+# Check if session storage is already configured
+existing_fs = rt.get('filesystemConfigurations', [])
+has_session_storage = any(
+    'sessionStorage' in fs for fs in existing_fs
+)
+
+if has_session_storage:
+    print('  Session storage already configured — skipping.')
+    sys.exit(0)
+
+# Add session storage config (full replace — must include all fields)
+print('  Adding filesystemConfigurations to runtime...')
+client.update_agent_runtime(
+    agentRuntimeId='$_early_runtime_id',
+    agentRuntimeArtifact=rt['agentRuntimeArtifact'],
+    roleArn=rt['roleArn'],
+    networkConfiguration=rt['networkConfiguration'],
+    environmentVariables=rt.get('environmentVariables', {}),
+    filesystemConfigurations=[
+        {'sessionStorage': {'mountPath': '/mnt/workspace'}}
+    ],
+)
+print('  Session storage configured: /mnt/workspace')
+" 2>&1 || echo "  WARNING: Failed to configure session storage (non-fatal)."
+  else
+    echo "  WARNING: Could not determine runtime ID — skipping session storage config."
+  fi
+
   # Read runtime ID and endpoint ID from toolkit
   echo "--- Reading runtime info ---"
   TOOLKIT_STATUS=$("$AGENTCORE_CLI" status --agent openclaw_agent --verbose 2>&1 || true)


### PR DESCRIPTION
## Summary

- Add AgentCore Session Storage as primary workspace persistence layer (`/mnt/workspace`)
- Symlink `~/.openclaw` → `/mnt/workspace/.openclaw` — transparent to OpenClaw and all skills
- S3 backup continues at 5 min interval (unchanged) as cold backup
- `deploy.sh` automatically configures `filesystemConfigurations` after `agentcore deploy`

## Files Changed

| File | Change |
|------|--------|
| `bridge/agentcore-contract.js` | `setupSessionStorageSymlink()` — symlink creation with cross-device copy fallback |
| `bridge/workspace-sync.js` | `setBackupMode()` API (available for future tuning) |
| `scripts/deploy.sh` | Configure `filesystemConfigurations` via `update-agent-runtime` API after deploy (idempotent) |
| `CLAUDE.md` | Document session storage architecture, version update caveat, VPC/IAM notes |

## How It Works

```
First invocation:
  1. Check /mnt/workspace exists (session storage mount)
  2. Create symlink: ~/.openclaw -> /mnt/workspace/.openclaw
  3. If session storage has data (resumed session) -> skip S3 restore
  4. If empty (new session / version update) -> restore from S3 backup
  5. S3 sync continues at 5 min interval as backup
```

## Deployment

`deploy.sh` handles everything automatically:
```bash
./scripts/deploy.sh  # Phase 2 now includes session storage config
```

The script calls `update-agent-runtime` with:
```python
filesystemConfigurations=[{"sessionStorage": {"mountPath": "/mnt/workspace"}}]
```

## Operational Notes

- **`update-agent-runtime` clears session storage** — S3 backup auto-restores, but changes since last 5 min backup may be lost
- **VPC permissions**: S3 Gateway Endpoint allows all S3 by default — no change needed
- **IAM**: Session storage is platform-managed — no execution role changes needed
- **14-day inactivity** also clears session storage

## Test Plan

- [x] Deploy to us-west-2, verify symlink creation in container logs
- [x] Verify OpenClaw startup time unchanged (~5-6s)
- [x] Verify S3 sync continues at 5 min interval
- [x] Stop session → resume → verify data persists from session storage

Generated with [Claude Code](https://claude.com/claude-code)