### PR TITLE
fix(browser): enable browser integration for AgentCore deployments

### DIFF
--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -629,6 +629,31 @@ function writeOpenClawConfig() {
       ].join("\n"),
     );
     console.log("[contract] AGENTS.md written");
+
+    // Also upload to S3 so the proxy's system prompt injection picks it up.
+    // The proxy reads AGENTS.md from S3 (not local filesystem), so without
+    // this sync the proxy would inject the stale 156-byte default template.
+    const namespace = currentNamespace;
+    const bucket = process.env.S3_USER_FILES_BUCKET;
+    if (bucket && namespace) {
+      const agentsContent = fs.readFileSync(agentsMdPath, "utf-8");
+      (async () => {
+        try {
+          const { PutObjectCommand } = require("@aws-sdk/client-s3");
+          const { S3Client } = require("@aws-sdk/client-s3");
+          const s3 = new S3Client({ region: process.env.AWS_REGION || "us-east-1" });
+          await s3.send(new PutObjectCommand({
+            Bucket: bucket,
+            Key: `${namespace}/AGENTS.md`,
+            Body: agentsContent,
+            ContentType: "text/markdown",
+          }));
+          console.log(`[contract] AGENTS.md synced to S3 (${agentsContent.length} bytes)`);
+        } catch (err) {
+          console.warn(`[contract] Failed to sync AGENTS.md to S3: ${err.message}`);
+        }
+      })();
+    }
   }
 }
 
@@ -715,7 +740,7 @@ async function initBrowserSession(userId) {
       browserIdentifier,
       name: userId.replace(/[^a-zA-Z0-9-]/g, "-").slice(0, 64),
       sessionTimeoutSeconds: BROWSER_SESSION_TIMEOUT_SECONDS,
-      viewportConfiguration: {
+      viewPort: {
         width: 1280,
         height: 720,
       },
@@ -968,8 +993,9 @@ async function init(userId, actorId, channel) {
     // Wait for lock cleanup to complete before starting OpenClaw
     await lockCleanupPromise;
 
-    // Write OpenClaw config and start gateway (non-blocking)
-    writeOpenClawConfig();
+    // NOTE: writeOpenClawConfig() is called AFTER setupSessionStorageSymlink()
+    // below, so that AGENTS.md is written to the symlinked path (session storage)
+    // and not overwritten by stale data from a previous session.
     console.log("[contract] Starting OpenClaw gateway (headless)...");
     // Build scoped env for OpenClaw — excludes container credentials,
     // uses credential_process for scoped S3 access only.
@@ -1030,6 +1056,10 @@ async function init(userId, actorId, channel) {
 
     // Session storage: symlink .openclaw → /mnt/workspace/.openclaw if available
     const sessionStorageAvailable = setupSessionStorageSymlink();
+
+    // Write OpenClaw config AFTER symlink — ensures AGENTS.md lands in the
+    // symlinked path and is not overwritten by stale session storage data.
+    writeOpenClawConfig();
 
     // Restore workspace from S3 if session storage is empty or unavailable
     if (sessionStorageAvailable) {

--- a/bridge/skills/agentcore-browser/common.js
+++ b/bridge/skills/agentcore-browser/common.js
@@ -1,6 +1,14 @@
 "use strict";
 const fs = require("fs");
 
+// Ensure /app/node_modules is in the module search path — OpenClaw's exec tool
+// may not forward NODE_PATH to child processes.
+if (!process.env.NODE_PATH?.includes("/app/node_modules")) {
+  require("module").Module._initPaths &&
+    (process.env.NODE_PATH = [process.env.NODE_PATH, "/app/node_modules"].filter(Boolean).join(":"));
+  require("module").Module._initPaths();
+}
+
 const BROWSER_SESSION_FILE = "/tmp/agentcore-browser-session.json";
 const CONTENT_TRUNCATE_CHARS = 8000;
 const NAV_TIMEOUT_MS = 30000;
@@ -26,7 +34,7 @@ async function connectBrowser() {
     headers: session.headers || {},
   });
   const contexts = browser.contexts();
-  const context = contexts.length > 0 ? contexts[0] : await browser.newContext();
+  const context = contexts.length > 0 ? contexts[0] : await browser.newContext({ ignoreHTTPSErrors: true });
   const pages = context.pages();
   const page = pages.length > 0 ? pages[0] : await context.newPage();
   return {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -188,6 +188,22 @@ read_cdk_outputs() {
     --query "Stacks[0].Outputs[?contains(OutputKey,'SecretsCmk')].OutputValue" \
     --output text)
 
+  # Read browser identifier (optional, only if enable_browser=true)
+  ENABLE_BROWSER=$(python3 -c "import json; print(str(json.load(open('$PROJECT_DIR/cdk.json'))['context'].get('enable_browser', False)).lower())")
+  BROWSER_IDENTIFIER=""
+  if [ "$ENABLE_BROWSER" = "true" ]; then
+    BROWSER_IDENTIFIER=$(aws cloudformation describe-stacks \
+      --stack-name OpenClawAgentCore --region "$REGION" \
+      --query "Stacks[0].Outputs[?OutputKey=='BrowserIdentifier'].OutputValue" \
+      --output text 2>/dev/null || echo "")
+    if [ -n "$BROWSER_IDENTIFIER" ] && [ "$BROWSER_IDENTIFIER" != "None" ]; then
+      echo "  Browser ID:     $BROWSER_IDENTIFIER"
+    else
+      echo "  Browser:        enable_browser=true but no BrowserIdentifier output found (region may not support it)"
+      BROWSER_IDENTIFIER=""
+    fi
+  fi
+
   # Read config values from cdk.json
   DEFAULT_MODEL_ID=$(python3 -c "import json; print(json.load(open('$PROJECT_DIR/cdk.json'))['context'].get('default_model_id','global.anthropic.claude-opus-4-6-v1'))")
   SUBAGENT_MODEL_ID=$(python3 -c "import json; print(json.load(open('$PROJECT_DIR/cdk.json'))['context'].get('subagent_model_id',''))")
@@ -290,7 +306,8 @@ phase2_toolkit() {
     --env "IDENTITY_TABLE_NAME=openclaw-identity" \
     --env "CRON_LEAD_TIME_MINUTES=$CRON_LEAD_TIME" \
     --env "SUBAGENT_BEDROCK_MODEL_ID=$SUBAGENT_MODEL_ID" \
-    --env "TELEGRAM_CHANNEL_SECRET_ID=$TELEGRAM_CHANNEL_SECRET_ID"
+    --env "TELEGRAM_CHANNEL_SECRET_ID=$TELEGRAM_CHANNEL_SECRET_ID" \
+    ${BROWSER_IDENTIFIER:+--env "BROWSER_IDENTIFIER=$BROWSER_IDENTIFIER"}
 
   # --- Configure session storage (not supported by agentcore CLI yet) ---
   echo "--- Configuring session storage ---"


### PR DESCRIPTION
## Summary

- Fix deploy.sh to read `BrowserIdentifier` from CDK outputs and pass it as `BROWSER_IDENTIFIER` env var to the container
- Fix `StartBrowserSessionCommand` parameter name (`viewportConfiguration` → `viewPort`)
- Fix `writeOpenClawConfig()` call order to run after symlink setup, preventing AGENTS.md from being overwritten
- Sync AGENTS.md to S3 so the proxy injects browser instructions into the system prompt
- Fix `playwright-core` module resolution in browser skill scripts (NODE_PATH not forwarded by OpenClaw exec)
- Add `ignoreHTTPSErrors` for CDP browser context in VPC environments

## Test plan

- [ ] Deploy with `enable_browser=true` in `cdk.json`
- [ ] Verify `BROWSER_IDENTIFIER` appears in container env vars
- [ ] Send browser navigation request via Telegram bot
- [ ] Verify screenshot delivery works end-to-end
- [ ] Test with `enable_browser=false` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)