### PR TITLE
feat: enable session storage backup mode when persistent filesystem is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ AgentCore microVMs are ephemeral — they're destroyed when idle. OpenClaw store
 
 This lets the system behave like a persistent server (continuous conversation history) while benefiting from serverless economics (no idle compute costs).
 
+### Session Storage (Persistent Filesystem)
+
+When [Managed Session Storage](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-persistent-filesystems.html) is available, `.openclaw/` persists across stop/resume cycles via `/mnt/workspace`, with S3 as a cold backup. Configured automatically by `deploy.sh`. See [docs/session-storage.md](docs/session-storage.md).
+
 ### Security
 
 This solution applies **defense-in-depth** across network, application, identity, and data layers. Key controls include:

--- a/bridge/agentcore-contract.js
+++ b/bridge/agentcore-contract.js
@@ -1031,9 +1031,12 @@ async function init(userId, actorId, channel) {
     // Session storage: symlink .openclaw → /mnt/workspace/.openclaw if available
     const sessionStorageAvailable = setupSessionStorageSymlink();
 
-    // Restore workspace from S3 if session storage is empty or unavailable
+    // Restore workspace from S3 and configure sync mode based on session storage availability
     if (sessionStorageAvailable) {
-      // Check if session storage .openclaw dir has content (non-empty = resumed session)
+      // Session storage is primary — S3 becomes a cold backup (30min instead of 5min)
+      workspaceSync.setBackupMode(true);
+
+      // Check if session storage already has data (resumed session)
       const mountedOpenclawDir = `${SESSION_STORAGE_MOUNT}/.openclaw`;
       let hasContent = false;
       try {

--- a/docs/session-storage.md
+++ b/docs/session-storage.md
@@ -1,0 +1,26 @@
+# Session Storage (Public Preview)
+
+AgentCore Runtime supports [Managed Session Storage](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-persistent-filesystems.html) — a persistent filesystem at `/mnt/workspace` that survives stop/resume cycles. Data is retained for 14 days of idle time and refreshed on endpoint version updates. See the [launch blog](https://aws.amazon.com/blogs/machine-learning/persist-session-state-with-filesystem-configuration-and-execute-shell-commands/) for details.
+
+## Integration
+
+`scripts/deploy.sh` configures session storage automatically via `filesystemConfigurations`. At runtime:
+
+1. **`agentcore-contract.js`** symlinks `~/.openclaw` → `/mnt/workspace/.openclaw`
+2. On resumed sessions (storage has data), S3 restore is skipped
+3. On new sessions (storage empty), workspace is restored from S3 once
+4. S3 sync switches to **backup mode** (every 30 min vs 5 min) — session storage is primary
+
+If session storage is unavailable, the system falls back to S3 as primary with no changes needed.
+
+## What Persists
+
+Session storage preserves the entire `~/.openclaw/` directory, including conversation history, cron jobs, memory, credentials, caches, and logs. Two files are regenerated on every init regardless: `openclaw.json` (gateway config) and `AGENTS.md` (agent instructions tied to the container version).
+
+Notably, session storage also retains files that S3 backup skips (caches, `node_modules/`, logs, media) — so resumed sessions are faster than cold S3 restores.
+
+```
+~/.openclaw  ──symlink──▶  /mnt/workspace/.openclaw  (persistent)
+                                    │
+                              S3 cold backup (every 30 min)
+```


### PR DESCRIPTION
## Summary

Wires AgentCore [Managed Session Storage](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-persistent-filesystems.html) as the primary workspace persistence layer, with S3 demoted to a cold backup.

## Changes

- **`bridge/agentcore-contract.js`** — Call `setBackupMode(true)` when session storage is detected at `/mnt/workspace`, reducing S3 sync from every 5 min to every 30 min
- **`docs/session-storage.md`** — Documents integration, what persists, and fallback behavior
- **`README.md`** — Adds session storage section linking to the doc

## Context

`deploy.sh` already configures `filesystemConfigurations` with `sessionStorage.mountPath: /mnt/workspace`, and `setupSessionStorageSymlink()` + `setBackupMode()` already exist. This PR wires them together — `setBackupMode(true)` was never called when session storage was detected.

Session storage preserves the full `~/.openclaw/` directory (conversation history, cron jobs, memory, credentials, caches) across stop/resume cycles. Files that S3 skip patterns would drop (caches, logs, media) are also retained, making resumed sessions faster than cold S3 restores.

Closes #59